### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   calculate-version:
     if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}


### PR DESCRIPTION
Potential fix for [https://github.com/stripsior/uptimekit/security/code-scanning/2](https://github.com/stripsior/uptimekit/security/code-scanning/2)

To fix the problem, an explicit permissions block should be added to the minimal scope required for the `calculate-version` job. Looking at the steps, the job checks out code, installs dependencies, invokes commands locally, checks for file changes, creates and uploads artifacts. None of these actions require write access to repository contents or any elevated permissions. The minimal permission needed is `contents: read` to fetch the repository for checkout. You should insert:

```yaml
permissions:
  contents: read
```
at the root of the workflow (applies to all jobs that do not override it), or specifically on the `calculate-version` job. Since `publish-docker` already has its own permissions (which are broader), the minimal fix is to add the block to the `calculate-version` job.

**File/Region to change:**  
- Edit `.github/workflows/canary.yml`.
- Add a `permissions:` block under the `calculate-version:` job key (indent aligned with `runs-on`), with `contents: read` as the only entry.

**What is needed:**  
- Indent correctly (2 spaces under the job level).
- No imports or method definitions are relevant for YAML.
- No other changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
