### PR TITLE
chore: sync versions

### DIFF
--- a/.changeset/big-numbers-vanish.md
+++ b/.changeset/big-numbers-vanish.md
@@ -1,7 +1,0 @@
----
-"@uptimekit/dash": patch
-"@uptimekit/api": patch
-"@uptimekit/auth": patch
----
-
-release 20.12.2025

--- a/apps/dash/CHANGELOG.md
+++ b/apps/dash/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @uptimekit/dash
 
+## 0.0.7
+
+### Patch Changes
+
+- f8c21da: release 20.12.2025
+- Updated dependencies [f8c21da]
+  - @uptimekit/api@0.0.7
+  - @uptimekit/auth@0.0.7
+
 ## 0.0.6
 
 ### Patch Changes

--- a/apps/dash/package.json
+++ b/apps/dash/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@uptimekit/dash",
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"private": true,
 	"scripts": {
 		"dev": "next dev --port=3000",

--- a/apps/status-page/CHANGELOG.md
+++ b/apps/status-page/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @uptimekit/status-page
 
+## 0.0.7
+
+### Patch Changes
+
+- Updated dependencies [f8c21da]
+  - @uptimekit/api@0.0.7
+
 ## 0.0.6
 
 ### Patch Changes

--- a/apps/status-page/package.json
+++ b/apps/status-page/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@uptimekit/status-page",
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"private": true,
 	"scripts": {
 		"dev": "next dev --port=3001",

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @uptimekit/api
 
+## 0.0.7
+
+### Patch Changes
+
+- f8c21da: release 20.12.2025
+- Updated dependencies [f8c21da]
+  - @uptimekit/auth@0.0.7
+
 ## 0.0.6
 
 ### Patch Changes

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@uptimekit/api",
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"private": true,
 	"exports": {
 		".": {

--- a/packages/auth/CHANGELOG.md
+++ b/packages/auth/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @uptimekit/auth
 
+## 0.0.7
+
+### Patch Changes
+
+- f8c21da: release 20.12.2025
+
 ## 0.0.6
 
 ### Patch Changes

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@uptimekit/auth",
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"private": true,
 	"exports": {
 		".": {


### PR DESCRIPTION
This pull request performs a patch release for several `@uptimekit` packages, bumping their versions to `0.0.7` and updating changelogs to reflect the new release. The changes primarily ensure that all related packages and their dependencies are kept in sync with the latest patch version.

Version bumps and changelog updates:

* Version numbers for `@uptimekit/dash`, `@uptimekit/status-page`, `@uptimekit/api`, and `@uptimekit/auth` were updated to `0.0.7` in their respective `package.json` files. [[1]](diffhunk://#diff-73449b3429ed5d21d9916fe909e7da339e6482a9e6c550df898c0f07e515f63eL3-R3) [[2]](diffhunk://#diff-3a2fe8297242206ba312ac72f5fc2eaf0fa77aab7c83adf6bb449d42849eaa49L3-R3) [[3]](diffhunk://#diff-069a572372e4f2574eb68db90e3d6ff4d0766296abec7b3c7b0f45b098d38fcaL3-R3) [[4]](diffhunk://#diff-79fbe1d958aec3ec2b3d46cdc5b9b34cd834f48550895ce9484f10c0f77a4a8fL3-R3)
* Changelogs for these packages were updated to document the `0.0.7` patch release and reference dependency updates. [[1]](diffhunk://#diff-6caf5a19f70322f045881c147c24483955e98935cd86a777729e9dcbd2847261R3-R11) [[2]](diffhunk://#diff-b19322336b9391b6e2285937341a9600744efbe341289aa04241c3fbac86b962R3-R9) [[3]](diffhunk://#diff-da944da0d630fb3f919c207f3cd93944217419187543777432c3af9096c46287R3-R10) [[4]](diffhunk://#diff-92a53f0443c779166479596f524334a472306c9c670de4548a641b3a0b706734R3-R8)

Cleanup:

* The obsolete changeset file `.changeset/big-numbers-vanish.md` was removed.