### PR TITLE
docs: update links in docs

### DIFF
--- a/apps/dash/.force
+++ b/apps/dash/.force
@@ -1,1 +1,0 @@
-force build

--- a/apps/docs/content/docs/installation/getting-started.mdx
+++ b/apps/docs/content/docs/installation/getting-started.mdx
@@ -85,7 +85,7 @@ If you prefer to build UptimeKit from source, follow these steps.
 1. Clone the repository:
 
 ```bash
-git clone https://github.com/stripsior/uptimekit.git
+git clone https://github.com/uptimekit/uptimekit.git
 cd uptimekit
 ```
 

--- a/apps/docs/src/components/landing/hero.tsx
+++ b/apps/docs/src/components/landing/hero.tsx
@@ -1,57 +1,62 @@
-import Link from "next/link";
 import { ArrowRight } from "lucide-react";
+import Link from "next/link";
 
 export function Hero() {
-  return (
-    <section className="relative overflow-hidden pt-16 md:pt-24 lg:pt-32 pb-16">
-      {/* Background Gradients */}
-      <div className="absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-hidden blur-3xl sm:-top-80">
-        <div className="relative left-[calc(50%-11rem)] aspect-[1155/678] w-[36.125rem] -translate-x-1/2 rotate-[30deg] bg-gradient-to-tr from-fd-border to-fd-background opacity-40 sm:left-[calc(50%-30rem)] sm:w-[72.1875rem]" 
-             style={{ clipPath: "polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)" }}
-        />
-      </div>
-      
-      <div className="container mx-auto px-4 md:px-6 relative z-10 text-center">
-        <div className="inline-flex items-center rounded-full border border-fd-border bg-fd-secondary/50 px-3 py-1 text-sm font-medium text-fd-secondary-foreground backdrop-blur-md mb-8">
-          <span className="flex h-2 w-2 rounded-full bg-fd-primary mr-2"></span>
-          The status page system you love
-        </div>
+	return (
+		<section className="relative overflow-hidden pt-16 pb-16 md:pt-24 lg:pt-32">
+			{/* Background Gradients */}
+			<div className="-top-40 -z-10 sm:-top-80 absolute inset-x-0 transform-gpu overflow-hidden blur-3xl">
+				<div
+					className="-translate-x-1/2 relative left-[calc(50%-11rem)] aspect-[1155/678] w-[36.125rem] rotate-[30deg] bg-gradient-to-tr from-fd-border to-fd-background opacity-40 sm:left-[calc(50%-30rem)] sm:w-[72.1875rem]"
+					style={{
+						clipPath:
+							"polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)",
+					}}
+				/>
+			</div>
 
-        <h1 className="mx-auto max-w-4xl text-5xl font-extrabold tracking-tight text-fd-foreground sm:text-6xl md:text-7xl mb-6 text-balance">
-          Build excellent status pages, <span className="text-fd-muted-foreground">your style.</span>
-        </h1>
+			<div className="container relative z-10 mx-auto px-4 text-center md:px-6">
+				<div className="mb-8 inline-flex items-center rounded-full border border-fd-border bg-fd-secondary/50 px-3 py-1 font-medium text-fd-secondary-foreground text-sm backdrop-blur-md">
+					<span className="mr-2 flex h-2 w-2 rounded-full bg-fd-primary" />
+					The status page system you love
+				</div>
 
-        <p className="mx-auto max-w-2xl text-lg text-fd-muted-foreground mb-10 text-balance">
-          Open source status page system designed for modern engineering teams. 
-          Monitor your services, notify your users, and stay transparent.
-        </p>
+				<h1 className="mx-auto mb-6 max-w-4xl text-balance font-extrabold text-5xl text-fd-foreground tracking-tight sm:text-6xl md:text-7xl">
+					Build excellent status pages,{" "}
+					<span className="text-fd-muted-foreground">your style.</span>
+				</h1>
 
-        <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-20">
-          <Link
-            href="/docs"
-            className="inline-flex h-12 items-center justify-center rounded-md bg-fd-primary px-8 text-sm font-medium text-fd-primary-foreground shadow transition-colors hover:bg-fd-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-fd-ring"
-          >
-            Getting Started
-          </Link>
-          <Link
-            href="https://github.com/stripsior/uptimekit"
-            target="_blank"
-            className="inline-flex h-12 items-center justify-center rounded-md border border-fd-border bg-fd-background px-8 text-sm font-medium shadow-sm transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-fd-ring"
-          >
-            Github
-            <ArrowRight className="ml-2 h-4 w-4" />
-          </Link>
-        </div>
+				<p className="mx-auto mb-10 max-w-2xl text-balance text-fd-muted-foreground text-lg">
+					Open source status page system designed for modern engineering teams.
+					Monitor your services, notify your users, and stay transparent.
+				</p>
 
-        {/* Panel Placeholder / Launchpad */}
-        <div className="relative mx-auto max-w-5xl">
-          <img 
-            src="https://r2.uptimekit.dev/banners/cover.png" 
-            alt="UptimeKit Dashboard Preview" 
-            className="w-full rounded-2xl border border-fd-border shadow-2xl"
-          />
-        </div>
-      </div>
-    </section>
-  );
+				<div className="mb-20 flex flex-col items-center justify-center gap-4 sm:flex-row">
+					<Link
+						href="/docs"
+						className="inline-flex h-12 items-center justify-center rounded-md bg-fd-primary px-8 font-medium text-fd-primary-foreground text-sm shadow transition-colors hover:bg-fd-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-fd-ring"
+					>
+						Getting Started
+					</Link>
+					<Link
+						href="https://github.com/uptimekit/uptimekit"
+						target="_blank"
+						className="inline-flex h-12 items-center justify-center rounded-md border border-fd-border bg-fd-background px-8 font-medium text-sm shadow-sm transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-fd-ring"
+					>
+						Github
+						<ArrowRight className="ml-2 h-4 w-4" />
+					</Link>
+				</div>
+
+				{/* Panel Placeholder / Launchpad */}
+				<div className="relative mx-auto max-w-5xl">
+					<img
+						src="https://r2.uptimekit.dev/banners/cover.png"
+						alt="UptimeKit Dashboard Preview"
+						className="w-full rounded-2xl border border-fd-border shadow-2xl"
+					/>
+				</div>
+			</div>
+		</section>
+	);
 }

--- a/apps/docs/src/components/landing/navbar.tsx
+++ b/apps/docs/src/components/landing/navbar.tsx
@@ -51,7 +51,7 @@ export function Navbar() {
 					<SearchTrigger />
 
 					<Link
-						href="https://github.com/stripsior/uptimekit"
+						href="https://github.com/uptimekit/uptimekit"
 						target="_blank"
 						className="rounded-md p-2 text-fd-muted-foreground transition-colors hover:bg-fd-muted hover:text-fd-foreground"
 					>

--- a/apps/status-page/.force
+++ b/apps/status-page/.force
@@ -1,1 +1,0 @@
-force build

--- a/apps/worker/.force
+++ b/apps/worker/.force
@@ -1,1 +1,0 @@
-force build


### PR DESCRIPTION
This pull request primarily updates repository references from the old GitHub organization to the new one across documentation and UI components, and removes `.force` build files from several applications. These changes help ensure that users and contributors are directed to the correct repository and streamline the build process.

Repository reference updates:

* Changed all GitHub URLs from `stripsior/uptimekit` to `uptimekit/uptimekit` in the installation documentation (`apps/docs/content/docs/installation/getting-started.mdx`), landing page hero component (`apps/docs/src/components/landing/hero.tsx`), and navbar component (`apps/docs/src/components/landing/navbar.tsx`). [[1]](diffhunk://#diff-cf314c5dfd5f0590c7d4e64acd7e36c551be78a073695f78b34fe2c3e1b02e46L88-R88) [[2]](diffhunk://#diff-c11e0123a55e16e7cdd3e81e2939f59005e1861df4735bd6f7fe8d3dd06ea826L1-R44) [[3]](diffhunk://#diff-50b35cadb3961c4579d0455ae0a437c2b20b3a64a3bb0bb36f1f1ea0c272dcdfL54-R54)

Build process cleanup:

* Removed `.force` build files from `apps/dash/.force`, `apps/status-page/.force`, and `apps/worker/.force` to simplify build management.