### PR TITLE
chore: remove auto release from release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,14 +107,6 @@ jobs:
           echo "Packages for Docker build:"
           echo "$PACKAGES" | jq .
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          name: Release ${{ env.VERSION }}
-          generate_release_notes: true
-          make_latest: true
-          prerelease: false
-
   publish-docker:
     name: Publish Docker Images
     needs: prepare


### PR DESCRIPTION
This pull request makes a small change to the `.github/workflows/release.yml` workflow by removing the step that creates a GitHub Release using the `softprops/action-gh-release` action. This means releases will no longer be automatically created as part of this workflow.