### PR TITLE
fix(ci): nothing to comment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,18 +50,22 @@ jobs:
 
       - name: Commit and Sync
         run: |
-          # Commit changes
-          git add .
-          git commit -m "chore: release v${{ env.VERSION }}"
+          # Commit changes only if there are any
+          if [ -n "$(git status --porcelain)" ]; then
+            git add .
+            git commit -m "chore: release v${{ env.VERSION }}"
+          else
+            echo "No changes to commit. Version might have been manually bumped."
+          fi
           
-          # Push to release branch (assuming tag was created on release branch or we want to force it there)
-          # We force update release branch to match this release commit
+          # Push to release branch
           git push origin HEAD:release
           
           # Sync to development
+          git fetch origin release
           git checkout development
           git pull origin development
-          git merge release
+          git merge origin/release
           git push origin development
 
       - name: Find All Packages with Dockerfiles


### PR DESCRIPTION
This pull request updates the release workflow in `.github/workflows/release.yml` to make the commit and sync steps more robust and reliable. The main improvements include ensuring commits are only made when there are actual changes, clarifying messaging, and making the branch synchronization process more explicit.

Release workflow improvements:

* The commit step now checks for uncommitted changes with `git status --porcelain` and only creates a commit if changes exist; otherwise, it prints a message indicating no commit is needed.
* The push to the release branch is clarified, removing unnecessary comments and ensuring the branch is updated appropriately.
* The sync to the development branch now explicitly fetches the latest `release` branch, merges `origin/release` instead of the local branch, and pushes the updated `development` branch to origin.