### PR TITLE
feat: add custom favicon support for status pages

### DIFF
--- a/apps/dash/src/app/(dashboard)/status-pages/[statusPageId]/settings/settings-form.tsx
+++ b/apps/dash/src/app/(dashboard)/status-pages/[statusPageId]/settings/settings-form.tsx
@@ -3,19 +3,25 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
+	ChevronDown,
 	ExternalLink,
 	Image as ImageIcon,
 	LayoutGrid,
 	LayoutList,
 	Loader2,
 } from "lucide-react";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import * as z from "zod";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import {
 	Form,
 	FormControl,
@@ -35,12 +41,18 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
 import { client, orpc } from "@/utils/orpc";
 
 const settingsSchema = z.object({
 	name: z.string().min(1, "Company name is required"),
 	slug: z.string().min(1, "Subdomain is required"),
 	logoUrl: z.string().url("Must be a valid URL").optional().or(z.literal("")),
+	faviconUrl: z
+		.string()
+		.url("Must be a valid URL")
+		.optional()
+		.or(z.literal("")),
 	websiteUrl: z
 		.string()
 		.url("Must be a valid URL")
@@ -100,6 +112,7 @@ export function SettingsForm({ statusPageId }: SettingsFormProps) {
 			name: "",
 			slug: "",
 			logoUrl: "",
+			faviconUrl: "",
 			websiteUrl: "",
 			contactUrl: "",
 			theme: "light",
@@ -110,22 +123,29 @@ export function SettingsForm({ statusPageId }: SettingsFormProps) {
 		},
 	});
 
+	const [faviconOpen, setFaviconOpen] = useState(false);
+
 	useEffect(() => {
 		if (statusPage) {
 			const design = (statusPage.design as any) || {};
-			form.reset({
-				name: statusPage.name,
-				slug: statusPage.slug,
-				logoUrl: design.logoUrl || "",
-				websiteUrl: design.websiteUrl || "",
-				contactUrl: design.contactUrl || "",
-				theme: design.theme || "light",
-				headerLayout: design.headerLayout || "vertical",
-				customDomain: statusPage.domain || "",
-				isPrivate: !statusPage.public,
-			});
+			form.reset(
+				{
+					name: statusPage.name,
+					slug: statusPage.slug,
+					logoUrl: design.logoUrl || "",
+					faviconUrl: design.faviconUrl || "",
+					websiteUrl: design.websiteUrl || "",
+					contactUrl: design.contactUrl || "",
+					theme: design.theme || "light",
+					headerLayout: design.headerLayout || "vertical",
+					customDomain: statusPage.domain || "",
+					isPrivate: !statusPage.public,
+					password: "",
+				},
+				{ keepDefaultValues: false },
+			);
 		}
-	}, [statusPage, form]);
+	}, [statusPage]);
 
 	function onSubmit(data: SettingsFormValues) {
 		// Require password when setting to private without an existing password
@@ -146,6 +166,7 @@ export function SettingsForm({ statusPageId }: SettingsFormProps) {
 			password: data.isPrivate ? data.password || undefined : null,
 			design: {
 				logoUrl: data.logoUrl,
+				faviconUrl: data.faviconUrl,
 				websiteUrl: data.websiteUrl,
 				contactUrl: data.contactUrl,
 				theme: data.theme,
@@ -325,7 +346,6 @@ export function SettingsForm({ statusPageId }: SettingsFormProps) {
 												onValueChange={(val) =>
 													field.onChange(val === "private")
 												}
-												defaultValue={field.value ? "private" : "public"}
 												value={field.value ? "private" : "public"}
 											>
 												<SelectTrigger className="w-full">
@@ -351,7 +371,6 @@ export function SettingsForm({ statusPageId }: SettingsFormProps) {
 											</FormLabel>
 											<Select
 												onValueChange={field.onChange}
-												defaultValue={field.value}
 												value={field.value}
 											>
 												<SelectTrigger className="w-full">
@@ -518,6 +537,61 @@ export function SettingsForm({ statusPageId }: SettingsFormProps) {
 									</FormItem>
 								)}
 							/>
+
+							{/* Favicon (Optional) */}
+							<Collapsible open={faviconOpen} onOpenChange={setFaviconOpen}>
+								<CollapsibleTrigger asChild>
+									<Button
+										variant="ghost"
+										className="flex w-full items-center justify-between p-0 hover:bg-transparent"
+										type="button"
+									>
+										<span className="text-muted-foreground text-sm">
+											Custom Favicon (Optional)
+										</span>
+										<ChevronDown
+											className={cn(
+												"h-4 w-4 text-muted-foreground transition-transform duration-200",
+												faviconOpen && "rotate-180",
+											)}
+										/>
+									</Button>
+								</CollapsibleTrigger>
+								<CollapsibleContent className="mt-4">
+									<FormField
+										control={form.control}
+										name="faviconUrl"
+										render={({ field }) => (
+											<FormItem>
+												<FormLabel>Favicon URL</FormLabel>
+												<div className="flex items-center gap-4 rounded-lg border bg-card p-4">
+													{field.value ? (
+														<div className="relative h-12 w-12 shrink-0 overflow-hidden rounded-md border bg-muted">
+															{/* eslint-disable-next-line @next/next/no-img-element */}
+															<img
+																src={field.value}
+																alt="Favicon preview"
+																className="h-full w-full object-contain p-1"
+															/>
+														</div>
+													) : (
+														<div className="flex h-12 w-12 items-center justify-center rounded-md border bg-muted">
+															<ImageIcon className="h-6 w-6 text-muted-foreground" />
+														</div>
+													)}
+													<div className="flex-1 space-y-2">
+														<Input placeholder="https://..." {...field} />
+														<p className="text-muted-foreground text-xs">
+															Custom favicon for browser tabs. If not set, your
+															logo will be used as the favicon.
+														</p>
+													</div>
+												</div>
+											</FormItem>
+										)}
+									/>
+								</CollapsibleContent>
+							</Collapsible>
 						</CardContent>
 					</Card>
 				</div>

--- a/apps/status-page/src/app/[slug]/page.tsx
+++ b/apps/status-page/src/app/[slug]/page.tsx
@@ -108,7 +108,10 @@ export async function generateMetadata({
 		title,
 		description,
 		applicationName: pageConfig?.name || "Status Page",
-		icons: logoUrl ? { icon: logoUrl } : undefined,
+		icons:
+			design.faviconUrl || logoUrl
+				? { icon: design.faviconUrl || logoUrl }
+				: undefined,
 		openGraph: {
 			title,
 			description,

--- a/apps/status-page/src/app/page.tsx
+++ b/apps/status-page/src/app/page.tsx
@@ -126,7 +126,10 @@ export async function generateMetadata() {
 		title,
 		description,
 		applicationName: pageConfig?.name || "Status Page",
-		icons: logoUrl ? { icon: logoUrl } : undefined,
+		icons:
+			design.faviconUrl || logoUrl
+				? { icon: design.faviconUrl || logoUrl }
+				: undefined,
 		openGraph: {
 			title,
 			description,

--- a/packages/api/src/routers/status-pages.ts
+++ b/packages/api/src/routers/status-pages.ts
@@ -185,6 +185,7 @@ export const statusPagesRouter = {
 						contactUrl: z.string().optional(),
 						theme: z.enum(["light", "dark"]).optional(),
 						headerLayout: z.enum(["vertical", "horizontal"]).optional(),
+						faviconUrl: z.string().optional(),
 					})
 					.optional(),
 				description: z.string().optional(),


### PR DESCRIPTION
Add optional faviconUrl field to status page design configuration with collapsible UI in settings form. Favicon automatically falls back to logoUrl if not set.

Changes:
- Add faviconUrl field to API schema (status-pages router)
- Implement collapsible favicon URL input in settings form
- Add favicon preview with image display
- Update metadata generation to use faviconUrl with logoUrl fallback
- Fix Select component hydration by removing defaultValue props
- Fix form reset to properly update cached default values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added custom favicon support to status page settings. Users can now specify a favicon URL with a preview thumbnail before saving. The favicon will display in browser tabs and page metadata when visitors access the status page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->