### PR TITLE
[codex] Add ClickHouse log TTL

### DIFF
--- a/packages/db/src/clickhouse.ts
+++ b/packages/db/src/clickhouse.ts
@@ -33,6 +33,28 @@ const CLICKHOUSE_BOOTSTRAP_QUERIES = [
 		) ENGINE = MergeTree()
 		ORDER BY (monitorId, timestamp)
 	`,
+	`
+	-- The main culprit (Every query you run)
+	ALTER TABLE system.query_log MODIFY TTL event_date + INTERVAL 3 DAY;
+
+	-- Thread-level details (Very high volume)
+	ALTER TABLE system.query_thread_log MODIFY TTL event_date + INTERVAL 3 DAY;
+
+	-- Sampling of query execution (Can get huge)
+	ALTER TABLE system.trace_log MODIFY TTL event_date + INTERVAL 3 DAY;
+
+	-- Async metrics (Snapshots of system state)
+	ALTER TABLE system.asynchronous_metric_log MODIFY TTL event_date + INTERVAL 3 DAY;
+
+	-- Periodic metrics
+	ALTER TABLE system.metric_log MODIFY TTL event_date + INTERVAL 3 DAY;
+
+	-- Error history
+	ALTER TABLE system.error_log MODIFY TTL event_date + INTERVAL 3 DAY;
+
+	-- Part mutations history
+	ALTER TABLE system.part_log MODIFY TTL event_date + INTERVAL 3 DAY;
+	`,
 ] as const;
 
 function getClickHouse(): ClickHouseClient {


### PR DESCRIPTION
## What changed
Adds bootstrap `ALTER TABLE ... MODIFY TTL` statements for high-volume ClickHouse system log tables in `packages/db/src/clickhouse.ts`.

## Why
The default ClickHouse system logs can grow quickly and retain data longer than needed for this deployment. Setting a 3-day TTL keeps those internal log tables bounded and reduces disk growth.

## Impact
This only affects ClickHouse internal log retention during schema bootstrap. Application tables remain unchanged.

## Validation
- `bunx @biomejs/biome check packages/db/src/clickhouse.ts`
