### PR TITLE
fix(status-page): protect private OG images and metadata

### DIFF
--- a/apps/status-page/src/app/[slug]/api/og/route.tsx
+++ b/apps/status-page/src/app/[slug]/api/og/route.tsx
@@ -2,6 +2,12 @@
 
 import { createLogger } from "@uptimekit/api/lib/logger";
 import { ImageResponse } from "next/og";
+import { type NextRequest, NextResponse } from "next/server";
+import {
+	hasStatusPageAccessToken,
+	isStatusPagePubliclyAccessible,
+} from "@/lib/access-check";
+import { getCookieName } from "@/lib/access-token";
 import {
 	getActiveMaintenances,
 	getActiveStatusPageReports,
@@ -53,8 +59,17 @@ function getSlugFromOgPath(pathname: string): string | undefined {
 	return undefined;
 }
 
+function privateImageResponse() {
+	return new NextResponse(null, {
+		status: 404,
+		headers: {
+			"Cache-Control": "private, no-store",
+		},
+	});
+}
+
 export async function GET(
-	request: Request,
+	request: NextRequest,
 	{ params }: { params: Promise<{ slug: string }> },
 ) {
 	const { slug: routeSlug } = await params;
@@ -106,6 +121,14 @@ export async function GET(
 				height: 630,
 			},
 		);
+	}
+
+	if (!isStatusPagePubliclyAccessible(pageConfig)) {
+		const token = request.cookies.get(getCookieName(pageConfig.id))?.value;
+
+		if (!hasStatusPageAccessToken(pageConfig, token)) {
+			return privateImageResponse();
+		}
 	}
 
 	const [activeReports, activeMaintenances] = await Promise.all([
@@ -323,6 +346,9 @@ export async function GET(
 		{
 			width: 1200,
 			height: 630,
+			headers: {
+				"Cache-Control": "private, no-store",
+			},
 		},
 	);
 }

--- a/apps/status-page/src/app/[slug]/api/og/route.tsx
+++ b/apps/status-page/src/app/[slug]/api/og/route.tsx
@@ -2,7 +2,7 @@
 
 import { createLogger } from "@uptimekit/api/lib/logger";
 import { ImageResponse } from "next/og";
-import { type NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
 import {
 	hasStatusPageAccessToken,
 	isStatusPagePubliclyAccessible,
@@ -14,6 +14,7 @@ import {
 	getMonitorStatus,
 	getStatusPageBySlug,
 } from "@/lib/db-queries";
+import { privateImageResponse } from "@/lib/og-responses";
 
 const logger = createLogger("STATUS-PAGE");
 
@@ -57,15 +58,6 @@ function getSlugFromOgPath(pathname: string): string | undefined {
 	}
 
 	return undefined;
-}
-
-function privateImageResponse() {
-	return new NextResponse(null, {
-		status: 404,
-		headers: {
-			"Cache-Control": "private, no-store",
-		},
-	});
 }
 
 export async function GET(

--- a/apps/status-page/src/app/[slug]/page.tsx
+++ b/apps/status-page/src/app/[slug]/page.tsx
@@ -1,8 +1,9 @@
 import { headers } from "next/headers";
 import { notFound } from "next/navigation";
-import { checkStatusPageAccess } from "@/lib/access-check";
+import { canAccessStatusPage, checkStatusPageAccess } from "@/lib/access-check";
 import { prepareStatusPageData } from "@/lib/data-preparer";
 import { getStatusPageBySlug } from "@/lib/db-queries";
+import { getHostFromHeaders, getProtocolFromHeaders } from "@/lib/route-utils";
 import { loadThemeComponent } from "@/lib/theme-loader";
 import { ThemePageWrapper } from "@/themes/theme-page-wrapper";
 
@@ -13,13 +14,24 @@ export async function generateMetadata({
 }) {
 	const { slug } = await params;
 	const headersList = await headers();
-	const host =
-		headersList.get("x-forwarded-host") ||
-		headersList.get("x-original-host") ||
-		headersList.get("host");
-	const protocol = headersList.get("x-forwarded-proto") || "https";
+	const host = getHostFromHeaders(headersList);
+	const protocol = getProtocolFromHeaders(headersList);
 
 	const pageConfig = await getStatusPageBySlug(slug);
+	const canAccessPage = pageConfig
+		? await canAccessStatusPage(pageConfig)
+		: false;
+
+	if (pageConfig && !canAccessPage) {
+		return {
+			title: "Private Status Page",
+			description: "This status page requires a password.",
+			robots: {
+				index: false,
+				follow: false,
+			},
+		};
+	}
 
 	const title = pageConfig?.name ? `${pageConfig.name} Status` : "Status Page";
 	const description = pageConfig?.name

--- a/apps/status-page/src/app/api/og/route.tsx
+++ b/apps/status-page/src/app/api/og/route.tsx
@@ -2,6 +2,12 @@
 
 import { createLogger } from "@uptimekit/api/lib/logger";
 import { ImageResponse } from "next/og";
+import { type NextRequest, NextResponse } from "next/server";
+import {
+	hasStatusPageAccessToken,
+	isStatusPagePubliclyAccessible,
+} from "@/lib/access-check";
+import { getCookieName } from "@/lib/access-token";
 import {
 	getActiveMaintenances,
 	getActiveStatusPageReports,
@@ -9,6 +15,7 @@ import {
 	getStatusPageByDomain,
 	getStatusPageBySlug,
 } from "@/lib/db-queries";
+import { getDomainFromHost, getHostFromHeaders } from "@/lib/route-utils";
 
 const logger = createLogger("STATUS-PAGE");
 
@@ -54,17 +61,23 @@ function getSlugFromOgPath(pathname: string): string | undefined {
 	return undefined;
 }
 
-export async function GET(request: Request) {
+function privateImageResponse() {
+	return new NextResponse(null, {
+		status: 404,
+		headers: {
+			"Cache-Control": "private, no-store",
+		},
+	});
+}
+
+export async function GET(request: NextRequest) {
 	const slug = getSlugFromOgPath(new URL(request.url).pathname);
-	const host =
-		request.headers.get("x-forwarded-host") ||
-		request.headers.get("x-original-host") ||
-		request.headers.get("host");
+	const host = getHostFromHeaders(request.headers);
 
 	let pageConfig = slug ? await getStatusPageBySlug(slug) : undefined;
 
 	if (!pageConfig && host) {
-		const domain = host.split(":")[0];
+		const domain = getDomainFromHost(host);
 		pageConfig = await getStatusPageByDomain(domain);
 	}
 
@@ -112,6 +125,14 @@ export async function GET(request: Request) {
 				height: 630,
 			},
 		);
+	}
+
+	if (!isStatusPagePubliclyAccessible(pageConfig)) {
+		const token = request.cookies.get(getCookieName(pageConfig.id))?.value;
+
+		if (!hasStatusPageAccessToken(pageConfig, token)) {
+			return privateImageResponse();
+		}
 	}
 
 	const [activeReports, activeMaintenances] = await Promise.all([
@@ -329,6 +350,9 @@ export async function GET(request: Request) {
 		{
 			width: 1200,
 			height: 630,
+			headers: {
+				"Cache-Control": "private, no-store",
+			},
 		},
 	);
 }

--- a/apps/status-page/src/app/api/og/route.tsx
+++ b/apps/status-page/src/app/api/og/route.tsx
@@ -2,7 +2,7 @@
 
 import { createLogger } from "@uptimekit/api/lib/logger";
 import { ImageResponse } from "next/og";
-import { type NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
 import {
 	hasStatusPageAccessToken,
 	isStatusPagePubliclyAccessible,
@@ -15,6 +15,7 @@ import {
 	getStatusPageByDomain,
 	getStatusPageBySlug,
 } from "@/lib/db-queries";
+import { privateImageResponse } from "@/lib/og-responses";
 import { getDomainFromHost, getHostFromHeaders } from "@/lib/route-utils";
 
 const logger = createLogger("STATUS-PAGE");
@@ -59,15 +60,6 @@ function getSlugFromOgPath(pathname: string): string | undefined {
 	}
 
 	return undefined;
-}
-
-function privateImageResponse() {
-	return new NextResponse(null, {
-		status: 404,
-		headers: {
-			"Cache-Control": "private, no-store",
-		},
-	});
 }
 
 export async function GET(request: NextRequest) {

--- a/apps/status-page/src/app/page.tsx
+++ b/apps/status-page/src/app/page.tsx
@@ -1,8 +1,13 @@
 import { headers } from "next/headers";
 import { notFound, redirect } from "next/navigation";
-import { checkStatusPageAccess } from "@/lib/access-check";
+import { canAccessStatusPage, checkStatusPageAccess } from "@/lib/access-check";
 import { prepareStatusPageData } from "@/lib/data-preparer";
 import { getStatusPageByDomain } from "@/lib/db-queries";
+import {
+	getDomainFromHost,
+	getHostFromHeaders,
+	getProtocolFromHeaders,
+} from "@/lib/route-utils";
 import { loadThemeComponent } from "@/lib/theme-loader";
 import { ThemePageWrapper } from "@/themes/theme-page-wrapper";
 
@@ -11,17 +16,14 @@ const DEFAULT_STATUS_PAGE_SLUG = process.env.DEFAULT_STATUS_PAGE_SLUG;
 
 function isStatusPageDomain(host: string): boolean {
 	if (!STATUS_PAGE_DOMAIN) return false;
-	const domain = host.split(":")[0];
+	const domain = getDomainFromHost(host);
 	return domain === STATUS_PAGE_DOMAIN;
 }
 
 export async function generateMetadata() {
 	const headersList = await headers();
-	const host =
-		headersList.get("x-forwarded-host") ||
-		headersList.get("x-original-host") ||
-		headersList.get("host");
-	const protocol = headersList.get("x-forwarded-proto") || "https";
+	const host = getHostFromHeaders(headersList);
+	const protocol = getProtocolFromHeaders(headersList);
 
 	if (!host) {
 		return {};
@@ -34,8 +36,22 @@ export async function generateMetadata() {
 		};
 	}
 
-	const domain = host.split(":")[0];
+	const domain = getDomainFromHost(host);
 	const pageConfig = await getStatusPageByDomain(domain);
+	const canAccessPage = pageConfig
+		? await canAccessStatusPage(pageConfig)
+		: false;
+
+	if (pageConfig && !canAccessPage) {
+		return {
+			title: "Private Status Page",
+			description: "This status page requires a password.",
+			robots: {
+				index: false,
+				follow: false,
+			},
+		};
+	}
 
 	const title = pageConfig?.name ? `${pageConfig.name} Status` : "Status Page";
 	const description = pageConfig?.name
@@ -98,10 +114,7 @@ function LandingPage() {
 
 export default async function StatusPage() {
 	const headersList = await headers();
-	const host =
-		headersList.get("x-forwarded-host") ||
-		headersList.get("x-original-host") ||
-		headersList.get("host");
+	const host = getHostFromHeaders(headersList);
 
 	if (!host) {
 		notFound();
@@ -115,7 +128,7 @@ export default async function StatusPage() {
 		return <LandingPage />;
 	}
 
-	const domain = host.split(":")[0];
+	const domain = getDomainFromHost(host);
 
 	const pageConfig = await getStatusPageByDomain(domain);
 

--- a/apps/status-page/src/lib/access-check.ts
+++ b/apps/status-page/src/lib/access-check.ts
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { cache } from "react";
 import { getCookieName, verifyAccessToken } from "./access-token";
 
 interface StatusPageConfig {
@@ -35,7 +36,7 @@ export function hasStatusPageAccessToken(
 	return Boolean(token && verifyAccessToken(token, statusPage.id));
 }
 
-export async function canAccessStatusPage(
+export const canAccessStatusPage = cache(async function canAccessStatusPage(
 	statusPage: StatusPageConfig,
 ): Promise<boolean> {
 	if (isStatusPagePubliclyAccessible(statusPage)) {
@@ -47,4 +48,4 @@ export async function canAccessStatusPage(
 	const token = cookieStore.get(cookieName)?.value;
 
 	return hasStatusPageAccessToken(statusPage, token);
-}
+});

--- a/apps/status-page/src/lib/access-check.ts
+++ b/apps/status-page/src/lib/access-check.ts
@@ -13,26 +13,38 @@ export async function checkStatusPageAccess(
 	statusPage: StatusPageConfig,
 	currentPath: string,
 ): Promise<void> {
-	// Public pages don't need access check
-	if (statusPage.public) {
-		return;
-	}
-
-	// Private page without password is accessible (owner may not have set password yet)
-	if (!statusPage.password) {
-		return;
-	}
-
-	// Check for valid access token in cookie
-	const cookieStore = await cookies();
-	const cookieName = getCookieName(statusPage.id);
-	const token = cookieStore.get(cookieName)?.value;
-
-	if (token && verifyAccessToken(token, statusPage.id)) {
+	if (await canAccessStatusPage(statusPage)) {
 		return;
 	}
 
 	// No valid token, redirect to password page
 	const redirectUrl = encodeURIComponent(currentPath);
 	redirect(`/password?pageId=${statusPage.id}&redirect=${redirectUrl}`);
+}
+
+export function isStatusPagePubliclyAccessible(
+	statusPage: StatusPageConfig,
+): boolean {
+	return statusPage.public || !statusPage.password;
+}
+
+export function hasStatusPageAccessToken(
+	statusPage: StatusPageConfig,
+	token: string | undefined,
+): boolean {
+	return Boolean(token && verifyAccessToken(token, statusPage.id));
+}
+
+export async function canAccessStatusPage(
+	statusPage: StatusPageConfig,
+): Promise<boolean> {
+	if (isStatusPagePubliclyAccessible(statusPage)) {
+		return true;
+	}
+
+	const cookieStore = await cookies();
+	const cookieName = getCookieName(statusPage.id);
+	const token = cookieStore.get(cookieName)?.value;
+
+	return hasStatusPageAccessToken(statusPage, token);
 }

--- a/apps/status-page/src/lib/db-queries.ts
+++ b/apps/status-page/src/lib/db-queries.ts
@@ -23,6 +23,7 @@ import {
 	isNull,
 	sql,
 } from "drizzle-orm";
+import { cache } from "react";
 import {
 	getIncidentHistoryCutoff,
 	type IncidentHistoryPeriod,
@@ -307,7 +308,7 @@ export const getStatusPageByDomain = async (domain: string) => {
 	);
 };
 
-export const getStatusPageBySlug = async (slug: string) => {
+export const getStatusPageBySlug = cache(async (slug: string) => {
 	return cached(
 		`status-page:slug:${slug}`,
 		600, // 10 minutes
@@ -335,7 +336,7 @@ export const getStatusPageBySlug = async (slug: string) => {
 			};
 		},
 	);
-};
+});
 
 export const getMonitorUptime = async (monitorId: string, days = 90) => {
 	return cached(

--- a/apps/status-page/src/lib/og-responses.ts
+++ b/apps/status-page/src/lib/og-responses.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+
+export function privateImageResponse() {
+	return new NextResponse(null, {
+		status: 404,
+		headers: {
+			"Cache-Control": "private, no-store",
+		},
+	});
+}

--- a/apps/status-page/src/lib/route-utils.ts
+++ b/apps/status-page/src/lib/route-utils.ts
@@ -19,6 +19,23 @@ function normalizeHost(host: string | null): string | undefined {
 	return normalizedHost;
 }
 
+function normalizeHeaderToken(value: string | null): string | undefined {
+	const token = value?.split(",").find((part) => part.trim().length > 0);
+
+	return token?.trim().toLowerCase();
+}
+
+/**
+ * Resolve the request host from a headers-like object.
+ *
+ * @param headersList - Any object with `Headers.get`, typically Next request headers.
+ * @returns The normalized host string, or `undefined` when no host is available.
+ *
+ * When `shouldTrustProxyHeaders` is enabled by
+ * `STATUS_PAGE_TRUST_PROXY_HEADERS=true`, checks `x-forwarded-host`, then
+ * `x-original-host`, then `host`; otherwise only `host` is trusted.
+ * Comma-separated values use the first token, and the result is trimmed/lowercased.
+ */
 export function getHostFromHeaders(
 	headersList: Pick<Headers, "get">,
 ): string | undefined {
@@ -33,16 +50,56 @@ export function getHostFromHeaders(
 	return normalizeHost(headersList.get("host"));
 }
 
+/**
+ * Extract the domain portion from a host value.
+ *
+ * @param host - A host header value after proxy trust selection.
+ * @returns A domain/host without a port; bracketed IPv6 is returned without brackets.
+ *
+ * Header trust is handled by `getHostFromHeaders` and `shouldTrustProxyHeaders`;
+ * this helper only parses the selected host value.
+ *
+ * Handles `host:port`, `[ipv6]:port`, plain hostnames, and unbracketed IPv6.
+ */
 export function getDomainFromHost(host: string): string {
-	return host.split(":")[0];
+	if (host.startsWith("[")) {
+		const closingBracketIndex = host.indexOf("]");
+
+		if (closingBracketIndex > 0) {
+			return host.slice(1, closingBracketIndex);
+		}
+	}
+
+	const firstColonIndex = host.indexOf(":");
+
+	if (firstColonIndex !== -1 && firstColonIndex === host.lastIndexOf(":")) {
+		return host.slice(0, firstColonIndex);
+	}
+
+	return host;
 }
 
+/**
+ * Resolve the protocol for absolute URLs in metadata.
+ *
+ * @param headersList - Any object with `Headers.get`, typically Next request headers.
+ * @returns `"http"` only for an explicit HTTP signal; otherwise `"https"`.
+ *
+ * When `shouldTrustProxyHeaders` is enabled by
+ * `STATUS_PAGE_TRUST_PROXY_HEADERS=true`, reads `x-forwarded-proto`, splits
+ * comma-separated values, and uses the first non-empty token. Otherwise uses
+ * `STATUS_PAGE_DEFAULT_PROTOCOL`, defaulting to HTTPS.
+ */
 export function getProtocolFromHeaders(
 	headersList: Pick<Headers, "get">,
 ): "http" | "https" {
 	if (!shouldTrustProxyHeaders()) {
-		return "https";
+		return process.env.STATUS_PAGE_DEFAULT_PROTOCOL?.toLowerCase() === "http"
+			? "http"
+			: "https";
 	}
 
-	return headersList.get("x-forwarded-proto") === "http" ? "http" : "https";
+	return normalizeHeaderToken(headersList.get("x-forwarded-proto")) === "http"
+		? "http"
+		: "https";
 }

--- a/apps/status-page/src/lib/route-utils.ts
+++ b/apps/status-page/src/lib/route-utils.ts
@@ -4,3 +4,45 @@ export function buildPath(basePath: string, slug?: string): string {
 	}
 	return basePath;
 }
+
+function shouldTrustProxyHeaders(): boolean {
+	return process.env.STATUS_PAGE_TRUST_PROXY_HEADERS === "true";
+}
+
+function normalizeHost(host: string | null): string | undefined {
+	const normalizedHost = host?.split(",")[0]?.trim().toLowerCase();
+
+	if (!normalizedHost) {
+		return undefined;
+	}
+
+	return normalizedHost;
+}
+
+export function getHostFromHeaders(
+	headersList: Pick<Headers, "get">,
+): string | undefined {
+	if (shouldTrustProxyHeaders()) {
+		return normalizeHost(
+			headersList.get("x-forwarded-host") ||
+				headersList.get("x-original-host") ||
+				headersList.get("host"),
+		);
+	}
+
+	return normalizeHost(headersList.get("host"));
+}
+
+export function getDomainFromHost(host: string): string {
+	return host.split(":")[0];
+}
+
+export function getProtocolFromHeaders(
+	headersList: Pick<Headers, "get">,
+): "http" | "https" {
+	if (!shouldTrustProxyHeaders()) {
+		return "https";
+	}
+
+	return headersList.get("x-forwarded-proto") === "http" ? "http" : "https";
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced access control for private status page OG images; unauthorized requests now return an error instead of generating shareable previews.
  * Private status pages are now properly excluded from search engine indexing.

* **Improvements**
  * Enhanced cache control for private pages to prevent unintended caching in shared systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->