### PR TITLE
[codex] implement monitor-assigned notifications

### DIFF
--- a/apps/dash/src/app/(dashboard)/integrations/page.tsx
+++ b/apps/dash/src/app/(dashboard)/integrations/page.tsx
@@ -1,4 +1,4 @@
-/** biome-ignore-all lint/suspicious/noExplicitAny: its okay */
+/** biome-ignore-all lint/suspicious/noExplicitAny: integration configs are provider-specific */
 "use client";
 
 import { useMutation, useQuery } from "@tanstack/react-query";
@@ -7,28 +7,135 @@ import { discordIntegrationMeta } from "@uptimekit/api/pkg/integrations/definiti
 import { telegramIntegrationMeta } from "@uptimekit/api/pkg/integrations/definitions/telegram-meta";
 import { webhookIntegrationMeta } from "@uptimekit/api/pkg/integrations/definitions/webhook-meta";
 import type { IntegrationDefinition } from "@uptimekit/api/pkg/integrations/registry";
-import { Settings2, Webhook } from "lucide-react";
+import { Plus, Send, Settings2, Trash2, Webhook } from "lucide-react";
 import { useState } from "react";
+import { sileo } from "sileo";
 import { z } from "zod";
 import { ConfigDialog } from "@/components/integrations/config-dialog";
-import { IntegrationCard } from "@/components/integrations/integration-card";
+import {
+	AlertDialog,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import {
+	Dialog,
+	DialogDescription,
+	DialogHeader,
+	DialogPanel,
+	DialogPopup,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import {
+	Empty,
+	EmptyContent,
+	EmptyDescription,
+	EmptyHeader,
+	EmptyTitle,
+} from "@/components/ui/empty";
 import { Skeleton } from "@/components/ui/skeleton";
-import { cn } from "@/lib/utils";
 import { client } from "@/utils/orpc";
 
+type ConfiguredNotification = {
+	id: string;
+	name: string;
+	type: string;
+	config: any;
+	active: boolean;
+	isDefault: boolean;
+	assignedMonitorCount: number;
+};
+
+const frontendRegistry = {
+	webhook: {
+		...webhookIntegrationMeta,
+		handler: async () => {},
+	} as IntegrationDefinition,
+	discord: {
+		...discordIntegrationMeta,
+		handler: async () => {},
+	} as IntegrationDefinition,
+	telegram: {
+		...telegramIntegrationMeta,
+		handler: async () => {},
+	} as IntegrationDefinition,
+	alertmanager: {
+		...alertManagerIntegrationMeta,
+		handler: async () => {},
+	} as IntegrationDefinition,
+};
+
+function getIntegrationDefinition(integration: {
+	id: string;
+	name?: string;
+	description?: string;
+	type?: "export" | "import";
+	events?: string[];
+}) {
+	return (
+		(frontendRegistry as Record<string, IntegrationDefinition>)[
+			integration.id
+		] ||
+		({
+			...integration,
+			name: integration.name || integration.id,
+			type: integration.type || "export",
+			configSchema: {
+				parse: () => ({}),
+				shape: { url: z.string() },
+			} as any,
+			events: integration.events || [],
+			handler: async () => {},
+		} as IntegrationDefinition)
+	);
+}
+
+function IntegrationIcon({
+	integration,
+}: {
+	integration: IntegrationDefinition;
+}) {
+	if (integration.logo) {
+		return (
+			<div className="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-lg border bg-muted sm:size-12">
+				{/* biome-ignore lint/performance/noImgElement: integration logos are static public assets */}
+				<img
+					src={integration.logo}
+					alt={integration.name}
+					className="size-6 object-contain sm:size-8"
+				/>
+			</div>
+		);
+	}
+
+	const Icon = integration.id === "webhook" ? Webhook : Settings2;
+
+	return (
+		<div className="flex size-10 shrink-0 items-center justify-center rounded-lg border bg-muted sm:size-12">
+			<Icon className="size-5 sm:size-6" />
+		</div>
+	);
+}
+
 export default function IntegrationsPage() {
+	const [providerDialogOpen, setProviderDialogOpen] = useState(false);
 	const [selectedIntegration, setSelectedIntegration] =
 		useState<IntegrationDefinition | null>(null);
-	const [activeTab, setActiveTab] = useState<"popular" | "import" | "export">(
-		"popular",
-	);
+	const [selectedConfig, setSelectedConfig] =
+		useState<ConfiguredNotification | null>(null);
+	const [configToRemove, setConfigToRemove] =
+		useState<ConfiguredNotification | null>(null);
+
 	const { data: availableIntegrations, isLoading: isLoadingAvailable } =
 		useQuery({
 			queryKey: ["integrations", "available"],
-			queryFn: async () => {
-				const res = await client.integrations.listAvailable();
-				return res;
-			},
+			queryFn: async () => client.integrations.listAvailable(),
 		});
 
 	const {
@@ -37,14 +144,18 @@ export default function IntegrationsPage() {
 		refetch,
 	} = useQuery({
 		queryKey: ["integrations", "configured"],
-		queryFn: async () => await client.integrations.listConfigured(),
+		queryFn: async () => client.integrations.listConfigured(),
 	});
 
 	const configureMutation = useMutation({
 		mutationFn: async (data: {
+			id?: string;
+			name: string;
 			type: string;
 			config: any;
-			active?: boolean;
+			active: boolean;
+			isDefault: boolean;
+			applyToExistingMonitors: boolean;
 		}) => {
 			await client.integrations.configure(data);
 		},
@@ -68,35 +179,16 @@ export default function IntegrationsPage() {
 		},
 	});
 
-	// Removed the require block as webhookIntegration is now imported at the top.
-	const frontendRegistry = {
-		webhook: {
-			...webhookIntegrationMeta,
-			handler: async () => {},
-		} as IntegrationDefinition,
-		discord: {
-			...discordIntegrationMeta,
-			handler: async () => {},
-		} as IntegrationDefinition,
-		telegram: {
-			...telegramIntegrationMeta,
-			handler: async () => {},
-		} as IntegrationDefinition,
-		alertmanager: {
-			...alertManagerIntegrationMeta,
-			handler: async () => {},
-		} as IntegrationDefinition,
-	};
+	const configuredNotifications =
+		(configuredConfigs as ConfiguredNotification[] | undefined) || [];
 
 	if (isLoadingAvailable || isLoadingConfigured) {
 		return (
 			<div className="flex flex-1 flex-col py-8">
-				<div className="mx-auto w-full max-w-6xl space-y-4 px-4">
+				<div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-4">
 					<Skeleton className="h-8 w-48" />
-					<div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-						<Skeleton className="h-48" />
-						<Skeleton className="h-48" />
-					</div>
+					<Skeleton className="h-24" />
+					<Skeleton className="h-24" />
 				</div>
 			</div>
 		);
@@ -104,173 +196,257 @@ export default function IntegrationsPage() {
 
 	return (
 		<div className="flex flex-1 flex-col py-8">
-			<div className="mx-auto w-full max-w-6xl space-y-4 px-4">
-				<div className="mb-6">
-					<h1 className="font-bold text-2xl">Integrations</h1>
-					<p className="text-muted-foreground">
-						Connect your monitoring with external tools.
-					</p>
+			<div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4">
+				<div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+					<div className="flex flex-col gap-1">
+						<h1 className="font-bold text-2xl">Notifications</h1>
+						<p className="text-muted-foreground">
+							Create notification channels and assign them to monitors.
+						</p>
+					</div>
+					<Button type="button" onClick={() => setProviderDialogOpen(true)}>
+						<Plus data-icon="inline-start" />
+						Add notification
+					</Button>
 				</div>
 
-				<div className="mb-6 flex space-x-4 border-b">
-					<button
-						type="button"
-						onClick={() => setActiveTab("popular")}
-						className={cn(
-							"border-b-2 px-4 py-2 font-medium text-sm transition-colors",
-							activeTab === "popular"
-								? "border-primary text-primary"
-								: "border-transparent text-muted-foreground hover:border-muted-foreground/30 hover:text-foreground",
-						)}
-					>
-						Popular
-					</button>
-					<button
-						type="button"
-						onClick={() => setActiveTab("import")}
-						className={cn(
-							"border-b-2 px-4 py-2 font-medium text-sm transition-colors",
-							activeTab === "import"
-								? "border-primary text-primary"
-								: "border-transparent text-muted-foreground hover:border-muted-foreground/30 hover:text-foreground",
-						)}
-					>
-						Importing data
-					</button>
-					<button
-						type="button"
-						onClick={() => setActiveTab("export")}
-						className={cn(
-							"border-b-2 px-4 py-2 font-medium text-sm transition-colors",
-							activeTab === "export"
-								? "border-primary text-primary"
-								: "border-transparent text-muted-foreground hover:border-muted-foreground/30 hover:text-foreground",
-						)}
-					>
-						Exporting data
-					</button>
-				</div>
+				{configuredNotifications.length === 0 ? (
+					<Empty className="rounded-lg border border-dashed py-12">
+						<EmptyHeader>
+							<EmptyTitle>No notifications configured</EmptyTitle>
+							<EmptyDescription>
+								Add a notification channel before assigning it to monitors.
+							</EmptyDescription>
+						</EmptyHeader>
+						<EmptyContent>
+							<Button type="button" onClick={() => setProviderDialogOpen(true)}>
+								<Plus data-icon="inline-start" />
+								Add notification
+							</Button>
+						</EmptyContent>
+					</Empty>
+				) : (
+					<div className="grid grid-cols-1 gap-4">
+						{configuredNotifications.map((config) => {
+							const integration = getIntegrationDefinition({
+								id: config.type,
+							});
 
-				{(() => {
-					const filteredIntegrations = availableIntegrations?.filter(
-						(integration: any) => {
-							const def = (frontendRegistry as any)[integration.id];
-							const type = def?.type || integration.type;
-
-							if (activeTab === "popular") return true;
-							if (activeTab === "import") return type === "import";
-							if (activeTab === "export") return type === "export";
-							return true;
-						},
-					);
-
-					if (!filteredIntegrations || filteredIntegrations.length === 0) {
-						return (
-							<div className="flex flex-col items-center justify-center rounded-lg border border-dashed bg-muted/10 py-12 text-center">
-								<p className="font-medium text-lg">No integrations found</p>
-								<p className="text-muted-foreground text-sm">
-									There are no integrations available in this category.
-								</p>
-							</div>
-						);
-					}
-
-					return (
-						<div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-2">
-							{filteredIntegrations.map((integrationMeta: any) => {
-								const config = configuredConfigs?.find(
-									(c: any) => c.type === integrationMeta.id,
-								);
-								// Use the imported definition to get the schema
-								const fullDef = (frontendRegistry as any)[
-									integrationMeta.id
-								] || {
-									// Fallback if not found locally but exists on backend (shouldn't happen if synced)
-									...integrationMeta,
-									configSchema: {
-										parse: () => {},
-										shape: { url: z.string() },
-									} as any,
-								};
-
-								// Icon mapping
-								let Icon: React.ReactNode;
-								if (fullDef.logo) {
-									Icon = (
-										<div className="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-lg border bg-muted sm:size-12">
-											{/* biome-ignore lint/performance/noImgElement: external integration logo URL */}
-											<img
-												src={fullDef.logo}
-												alt={fullDef.name}
-												className="size-6 object-contain sm:size-8"
-											/>
+							return (
+								<Card
+									key={config.id}
+									className="flex w-full flex-col gap-4 p-4 sm:flex-row sm:items-center sm:justify-between"
+								>
+									<div className="flex min-w-0 items-center gap-3 sm:gap-4">
+										<IntegrationIcon integration={integration} />
+										<div className="flex min-w-0 flex-col gap-2">
+											<div className="flex flex-wrap items-center gap-2">
+												<h2 className="truncate font-semibold text-sm">
+													{config.name}
+												</h2>
+												<Badge variant="outline">{integration.name}</Badge>
+												<Badge
+													variant={
+														integration.type === "export" ? "info" : "secondary"
+													}
+												>
+													{integration.type === "export" ? "Export" : "Import"}
+												</Badge>
+												{config.active ? (
+													<Badge variant="success">Active</Badge>
+												) : (
+													<Badge variant="secondary">Inactive</Badge>
+												)}
+												{config.isDefault && (
+													<Badge variant="warning">Default</Badge>
+												)}
+											</div>
+											<p className="text-muted-foreground text-sm">
+												Assigned to {config.assignedMonitorCount} monitor
+												{config.assignedMonitorCount === 1 ? "" : "s"}.
+											</p>
 										</div>
-									);
-								} else {
-									Icon =
-										integrationMeta.id === "webhook" ? (
-											<div className="flex size-10 shrink-0 items-center justify-center rounded-lg border bg-muted sm:size-12">
-												<Webhook className="size-5 sm:size-6" />
-											</div>
-										) : (
-											<div className="flex size-10 shrink-0 items-center justify-center rounded-lg border bg-muted sm:size-12">
-												<Settings2 className="size-5 sm:size-6" />
-											</div>
-										);
-								}
+									</div>
+									<div className="flex shrink-0 flex-wrap gap-2">
+										<Button
+											type="button"
+											variant="outline"
+											size="sm"
+											onClick={() => {
+												setSelectedIntegration(integration);
+												setSelectedConfig(config);
+											}}
+										>
+											<Settings2 data-icon="inline-start" />
+											Edit
+										</Button>
+										{integration.type === "export" && (
+											<Button
+												type="button"
+												variant="outline"
+												size="sm"
+												disabled={testMutation.isPending}
+												onClick={async () => {
+													try {
+														await testMutation.mutateAsync(config.id);
+														sileo.success({
+															title: "Test event sent successfully",
+														});
+													} catch (error: any) {
+														sileo.error({
+															title:
+																error.message || "Failed to send test event",
+														});
+													}
+												}}
+											>
+												<Send data-icon="inline-start" />
+												Test
+											</Button>
+										)}
+										<Button
+											type="button"
+											variant="destructive"
+											size="sm"
+											disabled={deleteMutation.isPending}
+											onClick={() => setConfigToRemove(config)}
+										>
+											<Trash2 data-icon="inline-start" />
+											Remove
+										</Button>
+									</div>
+								</Card>
+							);
+						})}
+					</div>
+				)}
+
+				<Dialog open={providerDialogOpen} onOpenChange={setProviderDialogOpen}>
+					<DialogPopup className="sm:max-w-2xl">
+						<DialogHeader>
+							<DialogTitle>Add notification</DialogTitle>
+							<DialogDescription>
+								Choose a provider, then configure where events should be sent.
+							</DialogDescription>
+						</DialogHeader>
+						<DialogPanel className="grid gap-3 sm:grid-cols-2">
+							{availableIntegrations?.map((integrationMeta) => {
+								const integration = getIntegrationDefinition(integrationMeta);
 
 								return (
-									<IntegrationCard
-										key={integrationMeta.id}
-										integration={fullDef}
-										configured={!!config}
-										active={config?.active}
-										icon={Icon}
-										category={fullDef.type === "export" ? "Export" : "Import"}
-										onConfigure={() => setSelectedIntegration(fullDef)}
-									/>
+									<button
+										key={integration.id}
+										type="button"
+										className="flex min-w-0 items-center gap-3 rounded-lg border bg-background p-4 text-left transition-colors hover:bg-muted/50"
+										onClick={() => {
+											setSelectedIntegration(integration);
+											setSelectedConfig(null);
+											setProviderDialogOpen(false);
+										}}
+									>
+										<IntegrationIcon integration={integration} />
+										<div className="min-w-0">
+											<div className="flex items-center gap-2">
+												<p className="truncate font-medium text-sm">
+													{integration.name}
+												</p>
+												<Badge variant="outline">
+													{integration.type === "export" ? "Export" : "Import"}
+												</Badge>
+											</div>
+											<p className="line-clamp-2 text-muted-foreground text-sm">
+												{integration.description}
+											</p>
+										</div>
+									</button>
 								);
 							})}
-						</div>
-					);
-				})()}
+						</DialogPanel>
+					</DialogPopup>
+				</Dialog>
 
-				{selectedIntegration &&
-					(() => {
-						const existingConfig = configuredConfigs?.find(
-							(c) => c.type === selectedIntegration.id,
-						);
-						return (
-							<ConfigDialog
-								open={!!selectedIntegration}
-								onOpenChange={(open) => !open && setSelectedIntegration(null)}
-								integration={selectedIntegration}
-								initialConfig={existingConfig?.config}
-								configId={existingConfig?.id}
-								onSave={async (config) => {
-									await configureMutation.mutateAsync({
-										type: selectedIntegration.id,
-										config,
-									});
-									setSelectedIntegration(null);
+				{selectedIntegration && (
+					<ConfigDialog
+						open={!!selectedIntegration}
+						onOpenChange={(open) => {
+							if (!open) {
+								setSelectedIntegration(null);
+								setSelectedConfig(null);
+							}
+						}}
+						integration={selectedIntegration}
+						initialConfig={selectedConfig?.config}
+						configId={selectedConfig?.id}
+						initialName={selectedConfig?.name}
+						initialActive={selectedConfig?.active ?? true}
+						initialIsDefault={selectedConfig?.isDefault ?? false}
+						onSave={async (values) => {
+							await configureMutation.mutateAsync({
+								id: selectedConfig?.id,
+								type: selectedIntegration.id,
+								...values,
+							});
+							setSelectedIntegration(null);
+							setSelectedConfig(null);
+						}}
+						onDelete={
+							selectedConfig
+								? async () => {
+										await deleteMutation.mutateAsync(selectedConfig.id);
+									}
+								: undefined
+						}
+						onTest={
+							selectedConfig
+								? async () => {
+										await testMutation.mutateAsync(selectedConfig.id);
+									}
+								: undefined
+						}
+					/>
+				)}
+
+				<AlertDialog
+					open={!!configToRemove}
+					onOpenChange={(open) => {
+						if (!open) setConfigToRemove(null);
+					}}
+				>
+					<AlertDialogContent>
+						<AlertDialogHeader>
+							<AlertDialogTitle>Remove notification</AlertDialogTitle>
+							<AlertDialogDescription>
+								Remove {configToRemove?.name}? Monitor assignments for this
+								notification will also be removed.
+							</AlertDialogDescription>
+						</AlertDialogHeader>
+						<AlertDialogFooter>
+							<AlertDialogCancel disabled={deleteMutation.isPending}>
+								Cancel
+							</AlertDialogCancel>
+							<Button
+								type="button"
+								variant="destructive"
+								disabled={deleteMutation.isPending}
+								onClick={async () => {
+									if (!configToRemove) return;
+
+									try {
+										await deleteMutation.mutateAsync(configToRemove.id);
+										setConfigToRemove(null);
+										sileo.success({ title: "Notification removed" });
+									} catch (error: any) {
+										sileo.error({
+											title: error.message || "Failed to remove notification",
+										});
+									}
 								}}
-								onDelete={
-									existingConfig
-										? async () => {
-												await deleteMutation.mutateAsync(existingConfig.id);
-											}
-										: undefined
-								}
-								onTest={
-									existingConfig
-										? async () => {
-												await testMutation.mutateAsync(existingConfig.id);
-											}
-										: undefined
-								}
-							/>
-						);
-					})()}
+							>
+								{deleteMutation.isPending ? "Removing..." : "Remove"}
+							</Button>
+						</AlertDialogFooter>
+					</AlertDialogContent>
+				</AlertDialog>
 			</div>
 		</div>
 	);

--- a/apps/dash/src/components/integrations/config-dialog.tsx
+++ b/apps/dash/src/components/integrations/config-dialog.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import type { IntegrationDefinition } from "@uptimekit/api/pkg/integrations/registry";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { sileo } from "sileo";
 import { z } from "zod";
 import { AlertManagerConfig } from "@/components/integrations/alertmanager-config";
@@ -16,6 +16,7 @@ import {
 	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
 	Dialog,
 	DialogClose,
@@ -28,6 +29,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 
 interface ConfigDialogProps {
 	open: boolean;
@@ -35,7 +37,16 @@ interface ConfigDialogProps {
 	integration: IntegrationDefinition;
 	initialConfig?: any;
 	configId?: string;
-	onSave: (config: any) => Promise<void>;
+	initialName?: string;
+	initialActive?: boolean;
+	initialIsDefault?: boolean;
+	onSave: (values: {
+		name: string;
+		config: any;
+		active: boolean;
+		isDefault: boolean;
+		applyToExistingMonitors: boolean;
+	}) => Promise<void>;
 	onDelete?: () => Promise<void>;
 	onTest?: () => Promise<void>;
 }
@@ -46,17 +57,38 @@ export function ConfigDialog({
 	integration,
 	initialConfig,
 	configId,
+	initialName,
+	initialActive = true,
+	initialIsDefault = false,
 	onSave,
 	onDelete,
 	onTest,
 }: ConfigDialogProps) {
+	const [name, setName] = useState(initialName || integration.name);
 	const [config, setConfig] = useState<Record<string, any>>(
 		initialConfig || {},
 	);
+	const [active, setActive] = useState(initialActive);
+	const [isDefault, setIsDefault] = useState(initialIsDefault);
+	const [applyToExistingMonitors, setApplyToExistingMonitors] = useState(false);
 	const [saving, setSaving] = useState(false);
 	const [testing, setTesting] = useState(false);
 	const [deleting, setDeleting] = useState(false);
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+
+	useEffect(() => {
+		setName(initialName || integration.name);
+		setConfig(initialConfig || {});
+		setActive(initialActive);
+		setIsDefault(initialIsDefault);
+		setApplyToExistingMonitors(false);
+	}, [
+		initialActive,
+		initialConfig,
+		initialIsDefault,
+		initialName,
+		integration.name,
+	]);
 
 	// Basic schema parsing for MVP (assumes object with string fields)
 	// In a real robust system, use something like 'auto-form'
@@ -66,6 +98,11 @@ export function ConfigDialog({
 	const isImportIntegration = integration.type === "import";
 
 	const handleSave = async () => {
+		if (!name.trim()) {
+			sileo.error({ title: "Notification name is required" });
+			return;
+		}
+
 		try {
 			// Validate client-side
 			integration.configSchema.parse(config);
@@ -81,11 +118,17 @@ export function ConfigDialog({
 
 		setSaving(true);
 		try {
-			await onSave(config);
+			await onSave({
+				name: name.trim(),
+				config,
+				active,
+				isDefault,
+				applyToExistingMonitors,
+			});
 			onOpenChange(false);
-			sileo.success({ title: "Integration saved" });
+			sileo.success({ title: "Notification saved" });
 		} catch (error: any) {
-			sileo.error({ title: error.message || "Failed to save integration" });
+			sileo.error({ title: error.message || "Failed to save notification" });
 			console.error(error);
 		} finally {
 			setSaving(false);
@@ -117,9 +160,9 @@ export function ConfigDialog({
 			await onDelete();
 			setDeleteDialogOpen(false);
 			onOpenChange(false);
-			sileo.success({ title: "Integration removed" });
+			sileo.success({ title: "Notification removed" });
 		} catch (error: any) {
-			sileo.error({ title: error.message || "Failed to remove integration" });
+			sileo.error({ title: error.message || "Failed to remove notification" });
 			console.error(error);
 		} finally {
 			setDeleting(false);
@@ -167,6 +210,63 @@ export function ConfigDialog({
 								);
 							})
 						)}
+
+						<div className="grid w-full items-center gap-1.5">
+							<Label htmlFor="notification-name">Name</Label>
+							<Input
+								id="notification-name"
+								value={name}
+								onChange={(event) => setName(event.target.value)}
+								placeholder={integration.name}
+							/>
+						</div>
+
+						<div className="flex items-center justify-between gap-4 rounded-lg bg-muted/50 p-4">
+							<div className="flex flex-col gap-1">
+								<Label htmlFor="notification-active">Active</Label>
+								<p className="text-muted-foreground text-sm">
+									Inactive notifications stay assigned but do not send events.
+								</p>
+							</div>
+							<Switch
+								id="notification-active"
+								checked={active}
+								onCheckedChange={setActive}
+							/>
+						</div>
+
+						<div className="flex items-center justify-between gap-4 rounded-lg bg-muted/50 p-4">
+							<div className="flex flex-col gap-1">
+								<Label htmlFor="notification-default">Default</Label>
+								<p className="text-muted-foreground text-sm">
+									Automatically select this notification for new monitors.
+								</p>
+							</div>
+							<Switch
+								id="notification-default"
+								checked={isDefault}
+								onCheckedChange={setIsDefault}
+							/>
+						</div>
+
+						<div className="flex items-start gap-3 rounded-lg bg-muted/50 p-4">
+							<Checkbox
+								id="notification-apply-existing"
+								checked={applyToExistingMonitors}
+								onCheckedChange={(checked) =>
+									setApplyToExistingMonitors(checked === true)
+								}
+							/>
+							<div className="flex flex-col gap-1">
+								<Label htmlFor="notification-apply-existing">
+									Apply to existing monitors
+								</Label>
+								<p className="text-muted-foreground text-sm">
+									Add this notification to all current monitors without removing
+									other assignments.
+								</p>
+							</div>
+						</div>
 					</DialogPanel>
 
 					<DialogFooter className="flex-col gap-2 sm:flex-row sm:justify-between">
@@ -208,9 +308,9 @@ export function ConfigDialog({
 			<AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
 				<AlertDialogContent>
 					<AlertDialogHeader>
-						<AlertDialogTitle>Remove integration</AlertDialogTitle>
+						<AlertDialogTitle>Remove notification</AlertDialogTitle>
 						<AlertDialogDescription>
-							Are you sure you want to remove this integration? This action
+							Are you sure you want to remove this notification? This action
 							cannot be undone.
 						</AlertDialogDescription>
 					</AlertDialogHeader>
@@ -218,9 +318,9 @@ export function ConfigDialog({
 						<AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
 						<Button
 							type="button"
+							variant="destructive"
 							onClick={handleDelete}
 							disabled={deleting}
-							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
 						>
 							{deleting ? "Removing..." : "Remove"}
 						</Button>

--- a/apps/dash/src/components/layout/app-sidebar.tsx
+++ b/apps/dash/src/components/layout/app-sidebar.tsx
@@ -59,7 +59,7 @@ const mainNav = [
 		icon: LayoutDashboard,
 	},
 	{
-		title: "Integrations",
+		title: "Notifications",
 		url: "/integrations",
 		icon: Grid2X2,
 	},
@@ -209,7 +209,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 						<SidebarMenu>
 							{mainNav
 								.filter((item) => {
-									if (item.title === "Integrations") {
+									if (item.title === "Notifications") {
 										const members = activeOrg?.members;
 										const role = members?.find(
 											(m) => m.userId === session?.user?.id,

--- a/apps/dash/src/components/monitors/create-form.tsx
+++ b/apps/dash/src/components/monitors/create-form.tsx
@@ -4,6 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
 	Activity,
+	Bell,
 	Braces,
 	ChevronRight,
 	Globe,
@@ -12,11 +13,11 @@ import {
 	Server,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { type UseFormReturn, useFieldArray, useForm } from "react-hook-form";
 import { sileo } from "sileo";
 import * as z from "zod";
-
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -79,6 +80,7 @@ const baseSchema = z.object({
 	interval: z.coerce.number().min(30),
 	groupId: z.string().nullish(),
 	tags: z.array(z.string()).default([]),
+	notificationIds: z.array(z.string()).default([]),
 	incidentPendingDuration: z.coerce.number().default(0),
 	incidentRecoveryDuration: z.coerce.number().default(0),
 	publishIncidentToStatusPage: z.boolean().default(false),
@@ -153,6 +155,14 @@ type ActiveWorkerOption = {
 	id: string;
 	name: string;
 	location: string;
+};
+
+type ConfiguredNotification = {
+	id: string;
+	name: string;
+	type: string;
+	active: boolean;
+	isDefault: boolean;
 };
 
 const heartbeatPeriodOptions = [
@@ -551,11 +561,18 @@ export function CreateMonitorForm({
 	);
 	const { data: groups } = useQuery(orpc.monitors.listGroups.queryOptions());
 	const { data: tags } = useQuery(orpc.monitors.listTags.queryOptions());
+	const { data: configuredNotifications } = useQuery({
+		queryKey: ["integrations", "configured"],
+		queryFn: async () =>
+			(await client.integrations.listConfigured()) as ConfiguredNotification[],
+	});
 
 	const [isAdvancedOpen, setIsAdvancedOpen] = useState(false);
 	const [groupsOpen, setGroupsOpen] = useState(false);
 	const [tagsOpen, setTagsOpen] = useState(false);
 	const [manageTagsOpen, setManageTagsOpen] = useState(false);
+	const [defaultNotificationsApplied, setDefaultNotificationsApplied] =
+		useState(false);
 
 	const getFormValuesFromInitialData = (): FormValues => {
 		const defaults = (initialData as any) || {};
@@ -566,6 +583,10 @@ export function CreateMonitorForm({
 			groupId: defaults.groupId ?? null,
 			tags:
 				defaults.tags?.map((t: any) => (typeof t === "string" ? t : t.id)) ||
+				[],
+			notificationIds:
+				defaults.notificationIds ||
+				defaults.notifications?.map((notification: any) => notification.id) ||
 				[],
 			checkSsl: defaults.checkSsl ?? true,
 			sslCertExpiryNotificationDays:
@@ -595,6 +616,20 @@ export function CreateMonitorForm({
 	const router = useRouter();
 	const utils = useQueryClient();
 
+	useEffect(() => {
+		if (monitorId || defaultNotificationsApplied || !configuredNotifications) {
+			return;
+		}
+
+		form.setValue(
+			"notificationIds",
+			configuredNotifications
+				.filter((notification) => notification.isDefault)
+				.map((notification) => notification.id),
+		);
+		setDefaultNotificationsApplied(true);
+	}, [configuredNotifications, defaultNotificationsApplied, form, monitorId]);
+
 	const { mutate, isPending } = useMutation({
 		mutationFn: async (data: FormValues) => {
 			// Transform form data to match API expectation
@@ -605,6 +640,7 @@ export function CreateMonitorForm({
 				groupId,
 				tags,
 				workerIds,
+				notificationIds,
 				incidentPendingDuration,
 				incidentRecoveryDuration,
 				publishIncidentToStatusPage,
@@ -618,6 +654,9 @@ export function CreateMonitorForm({
 				groupId,
 				tags,
 				workerIds,
+				...(monitorId || configuredNotifications !== undefined
+					? { notificationIds }
+					: {}),
 				incidentPendingDuration,
 				incidentRecoveryDuration,
 				publishIncidentToStatusPage,
@@ -679,6 +718,7 @@ export function CreateMonitorForm({
 	const selectedRegionCount = workerIds.length;
 	const isOverRegionLimit =
 		regionLimit !== null && selectedRegionCount > regionLimit;
+	const selectedNotificationIds = form.watch("notificationIds") || [];
 
 	// State for collapsible continents
 	const [openContinents, setOpenContinents] = useState<Record<string, boolean>>(
@@ -1117,6 +1157,142 @@ export function CreateMonitorForm({
 														</Collapsible>
 													))}
 											</div>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+							</CardContent>
+						</Card>
+					</div>
+
+					<Separator />
+
+					{/* Section: Notifications */}
+					<div className="grid grid-cols-1 gap-x-8 gap-y-8 md:grid-cols-3">
+						<div className="col-span-1">
+							<h2 className="font-semibold text-lg leading-tight tracking-tight">
+								Notifications
+							</h2>
+							<p className="mt-1 text-muted-foreground text-sm">
+								Choose which notification channels should receive this
+								monitor&apos;s incident events.
+							</p>
+						</div>
+
+						<Card className="col-span-1 md:col-span-2">
+							<CardContent className="flex flex-col gap-4 p-6">
+								<FormField
+									control={form.control}
+									name="notificationIds"
+									render={({ field }) => (
+										<FormItem>
+											<div className="flex items-center justify-between gap-4">
+												<FormLabel>
+													Selected notifications (
+													{selectedNotificationIds.length})
+												</FormLabel>
+												{configuredNotifications &&
+													configuredNotifications.length > 0 && (
+														<Button
+															type="button"
+															variant="link"
+															className="h-auto p-0 text-xs"
+															onClick={() => {
+																if (field.value?.length) {
+																	field.onChange([]);
+																	return;
+																}
+
+																field.onChange(
+																	configuredNotifications.map(
+																		(notification) => notification.id,
+																	),
+																);
+															}}
+														>
+															{field.value?.length
+																? "Deselect all"
+																: "Select all"}
+														</Button>
+													)}
+											</div>
+
+											{configuredNotifications &&
+											configuredNotifications.length > 0 ? (
+												<div className="grid grid-cols-1 gap-2">
+													{configuredNotifications.map((notification) => {
+														const checked = field.value?.includes(
+															notification.id,
+														);
+
+														return (
+															<FormItem
+																key={notification.id}
+																className="flex flex-row items-start gap-3 rounded-md bg-muted/50 p-4"
+															>
+																<FormControl>
+																	<Checkbox
+																		checked={checked}
+																		onCheckedChange={(nextChecked) => {
+																			if (nextChecked) {
+																				field.onChange([
+																					...(field.value || []),
+																					notification.id,
+																				]);
+																				return;
+																			}
+
+																			field.onChange(
+																				field.value?.filter(
+																					(value) => value !== notification.id,
+																				) || [],
+																			);
+																		}}
+																	/>
+																</FormControl>
+																<div className="flex min-w-0 flex-1 flex-col gap-2">
+																	<div className="flex flex-wrap items-center gap-2">
+																		<FormLabel className="cursor-pointer font-normal">
+																			{notification.name}
+																		</FormLabel>
+																		<Badge variant="outline">
+																			{notification.type}
+																		</Badge>
+																		{notification.isDefault && (
+																			<Badge variant="warning">Default</Badge>
+																		)}
+																		{notification.active ? (
+																			<Badge variant="success">Active</Badge>
+																		) : (
+																			<Badge variant="secondary">
+																				Inactive
+																			</Badge>
+																		)}
+																	</div>
+																</div>
+															</FormItem>
+														);
+													})}
+												</div>
+											) : (
+												<div className="flex flex-col items-start gap-3 rounded-lg border border-dashed p-6">
+													<div className="flex items-center gap-2 font-medium">
+														<Bell className="h-4 w-4" />
+														No notifications configured
+													</div>
+													<p className="text-muted-foreground text-sm">
+														Add a notification channel before assigning one to
+														this monitor.
+													</p>
+													<Button
+														type="button"
+														variant="outline"
+														onClick={() => router.push("/integrations")}
+													>
+														Manage notifications
+													</Button>
+												</div>
+											)}
 											<FormMessage />
 										</FormItem>
 									)}

--- a/packages/api/src/pkg/integrations/service.test.ts
+++ b/packages/api/src/pkg/integrations/service.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "bun:test";
+import { dedupeNotificationConfigs } from "./service";
+
+describe("notification config selection", () => {
+	it("deduplicates configs assigned through multiple monitors", () => {
+		const first = { id: "notification-1", name: "Primary" };
+		const second = { id: "notification-2", name: "Secondary" };
+		const duplicate = { id: "notification-1", name: "Duplicate" };
+
+		expect(dedupeNotificationConfigs([first, second, duplicate])).toEqual([
+			first,
+			second,
+		]);
+	});
+});

--- a/packages/api/src/pkg/integrations/service.ts
+++ b/packages/api/src/pkg/integrations/service.ts
@@ -1,4 +1,10 @@
 import { db } from "@uptimekit/db";
+import { incidentMonitor } from "@uptimekit/db/schema/incidents";
+import {
+	integrationConfig,
+	monitorNotification,
+} from "@uptimekit/db/schema/integrations";
+import { and, eq, inArray } from "drizzle-orm";
 import { eventBus } from "../../lib/events";
 import { alertManagerIntegration } from "./definitions/alertmanager";
 import { discordIntegration } from "./definitions/discord";
@@ -11,6 +17,20 @@ integrationRegistry.register(webhookIntegration);
 integrationRegistry.register(discordIntegration);
 integrationRegistry.register(telegramIntegration);
 integrationRegistry.register(alertManagerIntegration);
+
+export function dedupeNotificationConfigs<TConfig extends { id: string }>(
+	configs: TConfig[],
+) {
+	const configsById = new Map<string, TConfig>();
+
+	for (const config of configs) {
+		if (!configsById.has(config.id)) {
+			configsById.set(config.id, config);
+		}
+	}
+
+	return Array.from(configsById.values());
+}
 
 export class IntegrationService {
 	constructor() {
@@ -48,10 +68,9 @@ export class IntegrationService {
 			return;
 		}
 
-		// Fetch active integrations for this org
-		const configs = await db.query.integrationConfig.findMany({
-			where: (t, { eq, and }) =>
-				and(eq(t.organizationId, organizationId), eq(t.active, true)),
+		const configs = await this.getNotificationConfigs({
+			organizationId,
+			incidentId: payload.incidentId,
 		});
 
 		for (const config of configs) {
@@ -80,6 +99,58 @@ export class IntegrationService {
 			columns: { organizationId: true },
 		});
 		return inc?.organizationId || null;
+	}
+
+	private async getNotificationConfigs(input: {
+		organizationId: string;
+		incidentId?: string;
+	}) {
+		if (!input.incidentId) {
+			return db.query.integrationConfig.findMany({
+				where: (t, { eq, and }) =>
+					and(
+						eq(t.organizationId, input.organizationId),
+						eq(t.active, true),
+						eq(t.isDefault, true),
+					),
+			});
+		}
+
+		const incidentMonitors = await db
+			.select({ monitorId: incidentMonitor.monitorId })
+			.from(incidentMonitor)
+			.where(eq(incidentMonitor.incidentId, input.incidentId));
+
+		if (incidentMonitors.length === 0) {
+			return db.query.integrationConfig.findMany({
+				where: (t, { eq, and }) =>
+					and(
+						eq(t.organizationId, input.organizationId),
+						eq(t.active, true),
+						eq(t.isDefault, true),
+					),
+			});
+		}
+
+		const monitorIds = incidentMonitors.map((item) => item.monitorId);
+		const assignedConfigs = await db
+			.select({ config: integrationConfig })
+			.from(integrationConfig)
+			.innerJoin(
+				monitorNotification,
+				eq(monitorNotification.integrationConfigId, integrationConfig.id),
+			)
+			.where(
+				and(
+					eq(integrationConfig.organizationId, input.organizationId),
+					eq(integrationConfig.active, true),
+					inArray(monitorNotification.monitorId, monitorIds),
+				),
+			);
+
+		return dedupeNotificationConfigs(
+			assignedConfigs.map(({ config }) => config),
+		);
 	}
 }
 

--- a/packages/api/src/pkg/worker/service.ts
+++ b/packages/api/src/pkg/worker/service.ts
@@ -261,15 +261,6 @@ export async function processMonitorEvents(
 
 	if (incidentsToInsert.length > 0) {
 		await db.insert(incident).values(incidentsToInsert);
-		for (const inc of incidentsToInsert) {
-			eventBus.emit("incident.created", {
-				incidentId: inc.id,
-				organizationId: inc.organizationId,
-				title: inc.title,
-				description: inc.description,
-				severity: inc.severity as any,
-			});
-		}
 	}
 
 	if (incidentMonitorsToInsert.length > 0) {
@@ -282,6 +273,16 @@ export async function processMonitorEvents(
 
 	if (activitiesToInsert.length > 0) {
 		await db.insert(incidentActivity).values(activitiesToInsert);
+	}
+
+	for (const inc of incidentsToInsert) {
+		eventBus.emit("incident.created", {
+			incidentId: inc.id,
+			organizationId: inc.organizationId,
+			title: inc.title,
+			description: inc.description,
+			severity: inc.severity as any,
+		});
 	}
 
 	// Insert events to ClickHouse

--- a/packages/api/src/routers/integrations.ts
+++ b/packages/api/src/routers/integrations.ts
@@ -1,6 +1,10 @@
 import { ORPCError } from "@orpc/server"; /* manually added ORPCError import */
 import { db } from "@uptimekit/db";
-import { integrationConfig } from "@uptimekit/db/schema/integrations";
+import {
+	integrationConfig,
+	monitorNotification,
+} from "@uptimekit/db/schema/integrations";
+import { monitor } from "@uptimekit/db/schema/monitors";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure, writeProcedure } from "../index";
@@ -23,6 +27,8 @@ export const integrationsRouter = {
 			return integrations.map((i) => ({
 				id: i.id,
 				name: i.name,
+				type: i.type,
+				logo: i.logo,
 				description: i.description,
 				events: i.events,
 			}));
@@ -44,9 +50,15 @@ export const integrationsRouter = {
 
 			const configs = await db.query.integrationConfig.findMany({
 				where: (t, { eq }) => eq(t.organizationId, organizationId),
+				with: {
+					monitorNotifications: true,
+				},
 			});
 
-			return configs;
+			return configs.map(({ monitorNotifications, ...config }) => ({
+				...config,
+				assignedMonitorCount: monitorNotifications.length,
+			}));
 		}),
 
 	configure: writeProcedure
@@ -61,9 +73,13 @@ export const integrationsRouter = {
 		})
 		.input(
 			z.object({
+				id: z.string().optional(),
+				name: z.string().trim().min(1),
 				type: z.string(),
 				config: z.record(z.any(), z.any()), // We accept any JSON, validation happens inside or before
 				active: z.boolean().default(true),
+				isDefault: z.boolean().default(false),
+				applyToExistingMonitors: z.boolean().default(false),
 			}),
 		)
 		.handler(async ({ context, input }) => {
@@ -81,32 +97,66 @@ export const integrationsRouter = {
 				await assertSafeWebhookUrl(parsedConfig.url);
 			}
 
-			// Check if exists
-			const existing = await db.query.integrationConfig.findFirst({
-				where: (t, { eq, and }) =>
-					and(eq(t.organizationId, organizationId), eq(t.type, input.type)),
-			});
+			const notificationId = input.id ?? crypto.randomUUID();
 
-			if (existing) {
-				await db
-					.update(integrationConfig)
-					.set({
+			await db.transaction(async (tx) => {
+				if (input.id) {
+					const inputId = input.id;
+					const existing = await tx.query.integrationConfig.findFirst({
+						where: (t, { eq, and }) =>
+							and(eq(t.id, inputId), eq(t.organizationId, organizationId)),
+					});
+
+					if (!existing) {
+						throw new ORPCError("NOT_FOUND", {
+							message: "Integration not found",
+						});
+					}
+
+					await tx
+						.update(integrationConfig)
+						.set({
+							name: input.name,
+							type: input.type,
+							config: parsedConfig,
+							active: input.active,
+							isDefault: input.isDefault,
+							updatedAt: new Date(),
+						})
+						.where(eq(integrationConfig.id, existing.id));
+				} else {
+					await tx.insert(integrationConfig).values({
+						id: notificationId,
+						name: input.name,
+						organizationId,
+						type: input.type,
 						config: parsedConfig,
 						active: input.active,
-						updatedAt: new Date(),
-					})
-					.where(eq(integrationConfig.id, existing.id));
-			} else {
-				await db.insert(integrationConfig).values({
-					id: crypto.randomUUID(),
-					organizationId,
-					type: input.type,
-					config: parsedConfig,
-					active: input.active,
-				});
-			}
+						isDefault: input.isDefault,
+					});
+				}
 
-			return { success: true };
+				if (input.applyToExistingMonitors) {
+					const monitors = await tx
+						.select({ id: monitor.id })
+						.from(monitor)
+						.where(eq(monitor.organizationId, organizationId));
+
+					if (monitors.length > 0) {
+						await tx
+							.insert(monitorNotification)
+							.values(
+								monitors.map((monitorRecord) => ({
+									monitorId: monitorRecord.id,
+									integrationConfigId: notificationId,
+								})),
+							)
+							.onConflictDoNothing();
+					}
+				}
+			});
+
+			return { success: true, id: notificationId };
 		}),
 
 	delete: writeProcedure

--- a/packages/api/src/routers/monitors.ts
+++ b/packages/api/src/routers/monitors.ts
@@ -6,6 +6,10 @@ import {
 	incidentActivity,
 	incidentMonitor,
 } from "@uptimekit/db/schema/incidents";
+import {
+	integrationConfig,
+	monitorNotification,
+} from "@uptimekit/db/schema/integrations";
 import { monitor, monitorGroup } from "@uptimekit/db/schema/monitors";
 import { statusPageMonitor } from "@uptimekit/db/schema/status-pages";
 import { monitorTag, tag } from "@uptimekit/db/schema/tags";
@@ -124,6 +128,64 @@ async function getWorkersForMonitorAssignments(input: {
 	return workers;
 }
 
+async function getDefaultNotificationIds(organizationId: string) {
+	const defaults = await db
+		.select({ id: integrationConfig.id })
+		.from(integrationConfig)
+		.where(
+			and(
+				eq(integrationConfig.organizationId, organizationId),
+				eq(integrationConfig.active, true),
+				eq(integrationConfig.isDefault, true),
+			),
+		);
+
+	return defaults.map((item) => item.id);
+}
+
+async function assertNotificationIdsForOrganization(input: {
+	organizationId: string;
+	notificationIds: string[];
+}) {
+	const uniqueNotificationIds = [...new Set(input.notificationIds)];
+
+	if (uniqueNotificationIds.length === 0) {
+		return [];
+	}
+
+	const matchingNotifications = await db
+		.select({ id: integrationConfig.id })
+		.from(integrationConfig)
+		.where(
+			and(
+				eq(integrationConfig.organizationId, input.organizationId),
+				inArray(integrationConfig.id, uniqueNotificationIds),
+			),
+		);
+
+	if (matchingNotifications.length !== uniqueNotificationIds.length) {
+		throw new ORPCError("BAD_REQUEST", {
+			message: "One or more selected notifications are missing.",
+		});
+	}
+
+	return uniqueNotificationIds;
+}
+
+async function resolveNotificationIdsForCreate(input: {
+	organizationId: string;
+	notificationIds?: string[];
+}) {
+	if (input.notificationIds === undefined) {
+		return getDefaultNotificationIds(input.organizationId);
+	}
+
+	return assertNotificationIdsForOrganization({
+		organizationId: input.organizationId,
+		notificationIds: input.notificationIds,
+	});
+}
+
 export const monitorsRouter = {
 	list: protectedProcedure
 		.input(
@@ -209,6 +271,20 @@ export const monitorsRouter = {
 
 			// Batch fetch latest events and changes for all monitors to avoid N+1 query problem
 			const monitorIds = monitors.map((row) => row.monitor.id);
+			const notificationCounts =
+				monitorIds.length > 0
+					? await db
+							.select({
+								monitorId: monitorNotification.monitorId,
+								count: sql<number>`count(*)`.mapWith(Number),
+							})
+							.from(monitorNotification)
+							.where(inArray(monitorNotification.monitorId, monitorIds))
+							.groupBy(monitorNotification.monitorId)
+					: [];
+			const notificationCountMap = new Map(
+				notificationCounts.map((item) => [item.monitorId, item.count]),
+			);
 
 			// Fetch tags for all monitors
 			const tagsForMonitors =
@@ -301,6 +377,7 @@ export const monitorsRouter = {
 						? parseClickhouseTimestamp(latestChange.timestamp)
 						: null,
 					usedOn: usageMap.get(row.monitor.id) || 0,
+					notificationCount: notificationCountMap.get(row.monitor.id) || 0,
 				};
 			});
 
@@ -391,14 +468,17 @@ export const monitorsRouter = {
 				tags: z.array(z.string()).optional(),
 				config: z.record(z.any(), z.any()),
 				workerIds: z.array(z.string()).min(1),
+				notificationIds: z.array(z.string()).optional(),
 				incidentPendingDuration: z.number().min(0).default(0),
 				incidentRecoveryDuration: z.number().min(0).default(0),
 				publishIncidentToStatusPage: z.boolean().default(false),
 			}),
 		)
 		.handler(async ({ input, context }) => {
+			const organizationId = context.session.session.activeOrganizationId!;
+
 			await enforceMonitorQuotaOrThrow({
-				organizationId: context.session.session.activeOrganizationId!,
+				organizationId,
 				nextWorkerIds: input.workerIds,
 				nextActive: true,
 			});
@@ -411,39 +491,57 @@ export const monitorsRouter = {
 				},
 			});
 
-			const [newMonitor] = await db
-				.insert(monitor)
-				.values({
-					id: crypto.randomUUID(),
-					name: input.name,
-					organizationId: context.session.session.activeOrganizationId!,
-					type: input.type,
-					config: input.config,
-					locations: selectedWorkers.map(
-						(selectedWorker) => selectedWorker.location,
-					),
-					workerIds: input.workerIds,
-					groupId: input.groupId,
-					active: true,
-					pauseReason: null,
-					incidentPendingDuration: input.incidentPendingDuration,
-					incidentRecoveryDuration: input.incidentRecoveryDuration,
-					publishIncidentToStatusPage: input.publishIncidentToStatusPage,
-				})
-				.returning();
+			const notificationIds = await resolveNotificationIdsForCreate({
+				organizationId,
+				notificationIds: input.notificationIds,
+			});
 
-			if (!newMonitor) {
-				throw new ORPCError("INTERNAL_SERVER_ERROR");
-			}
+			const newMonitor = await db.transaction(async (tx) => {
+				const [createdMonitor] = await tx
+					.insert(monitor)
+					.values({
+						id: crypto.randomUUID(),
+						name: input.name,
+						organizationId,
+						type: input.type,
+						config: input.config,
+						locations: selectedWorkers.map(
+							(selectedWorker) => selectedWorker.location,
+						),
+						workerIds: input.workerIds,
+						groupId: input.groupId,
+						active: true,
+						pauseReason: null,
+						incidentPendingDuration: input.incidentPendingDuration,
+						incidentRecoveryDuration: input.incidentRecoveryDuration,
+						publishIncidentToStatusPage: input.publishIncidentToStatusPage,
+					})
+					.returning();
 
-			if (input.tags && input.tags.length > 0) {
-				await db.insert(monitorTag).values(
-					input.tags.map((tagId) => ({
-						monitorId: newMonitor.id,
-						tagId,
-					})),
-				);
-			}
+				if (!createdMonitor) {
+					throw new ORPCError("INTERNAL_SERVER_ERROR");
+				}
+
+				if (input.tags && input.tags.length > 0) {
+					await tx.insert(monitorTag).values(
+						input.tags.map((tagId) => ({
+							monitorId: createdMonitor.id,
+							tagId,
+						})),
+					);
+				}
+
+				if (notificationIds.length > 0) {
+					await tx.insert(monitorNotification).values(
+						notificationIds.map((notificationId) => ({
+							monitorId: createdMonitor.id,
+							integrationConfigId: notificationId,
+						})),
+					);
+				}
+
+				return createdMonitor;
+			});
 
 			return newMonitor;
 		}),
@@ -594,6 +692,7 @@ export const monitorsRouter = {
 				tags: z.array(z.string()).optional(),
 				config: z.record(z.any(), z.any()),
 				workerIds: z.array(z.string()).min(1),
+				notificationIds: z.array(z.string()).optional(),
 				incidentPendingDuration: z.number().min(0).default(0),
 				incidentRecoveryDuration: z.number().min(0).default(0),
 				publishIncidentToStatusPage: z.boolean().default(false),
@@ -627,40 +726,65 @@ export const monitorsRouter = {
 				},
 			});
 
-			await db
-				.update(monitor)
-				.set({
-					name: input.name,
-					type: input.type,
-					interval: input.interval,
-					groupId: input.groupId,
-					config: input.config,
-					locations: selectedWorkers.map(
-						(selectedWorker) => selectedWorker.location,
-					),
-					workerIds: input.workerIds,
-					incidentPendingDuration: input.incidentPendingDuration,
-					incidentRecoveryDuration: input.incidentRecoveryDuration,
-					publishIncidentToStatusPage: input.publishIncidentToStatusPage,
-					active: input.active,
-					pauseReason: null,
-				})
-				.where(eq(monitor.id, input.id));
+			const notificationIds =
+				input.notificationIds === undefined
+					? undefined
+					: await assertNotificationIdsForOrganization({
+							organizationId: existing.organizationId,
+							notificationIds: input.notificationIds,
+						});
 
-			if (input.tags) {
-				// Remove existing tags
-				await db.delete(monitorTag).where(eq(monitorTag.monitorId, input.id));
+			await db.transaction(async (tx) => {
+				await tx
+					.update(monitor)
+					.set({
+						name: input.name,
+						type: input.type,
+						interval: input.interval,
+						groupId: input.groupId,
+						config: input.config,
+						locations: selectedWorkers.map(
+							(selectedWorker) => selectedWorker.location,
+						),
+						workerIds: input.workerIds,
+						incidentPendingDuration: input.incidentPendingDuration,
+						incidentRecoveryDuration: input.incidentRecoveryDuration,
+						publishIncidentToStatusPage: input.publishIncidentToStatusPage,
+						active: input.active,
+						pauseReason: null,
+					})
+					.where(eq(monitor.id, input.id));
 
-				// Add new tags
-				if (input.tags.length > 0) {
-					await db.insert(monitorTag).values(
-						input.tags.map((tagId) => ({
-							monitorId: input.id,
-							tagId,
-						})),
-					);
+				if (input.tags) {
+					// Remove existing tags
+					await tx.delete(monitorTag).where(eq(monitorTag.monitorId, input.id));
+
+					// Add new tags
+					if (input.tags.length > 0) {
+						await tx.insert(monitorTag).values(
+							input.tags.map((tagId) => ({
+								monitorId: input.id,
+								tagId,
+							})),
+						);
+					}
 				}
-			}
+
+				if (notificationIds !== undefined) {
+					await tx
+						.delete(monitorNotification)
+						.where(eq(monitorNotification.monitorId, input.id));
+
+					if (notificationIds.length > 0) {
+						await tx.insert(monitorNotification).values(
+							notificationIds.map((notificationId) => ({
+								monitorId: input.id,
+								integrationConfigId: notificationId,
+							})),
+						);
+					}
+				}
+			});
 
 			return { success: true };
 		}),
@@ -733,6 +857,21 @@ export const monitorsRouter = {
 				.innerJoin(tag, eq(monitorTag.tagId, tag.id))
 				.where(eq(monitorTag.monitorId, found.monitor.id));
 
+			const notifications = await db
+				.select({
+					id: integrationConfig.id,
+					name: integrationConfig.name,
+					type: integrationConfig.type,
+					active: integrationConfig.active,
+					isDefault: integrationConfig.isDefault,
+				})
+				.from(monitorNotification)
+				.innerJoin(
+					integrationConfig,
+					eq(monitorNotification.integrationConfigId, integrationConfig.id),
+				)
+				.where(eq(monitorNotification.monitorId, found.monitor.id));
+
 			const monitorWorkerIds =
 				(found.monitor.workerIds as string[] | null) ?? [];
 			const monitorLocations =
@@ -746,6 +885,8 @@ export const monitorsRouter = {
 				...found.monitor,
 				group: found.monitor_group || null,
 				tags: monitorTags.map((mt) => mt.tag),
+				notificationIds: notifications.map((notification) => notification.id),
+				notifications,
 				workers: monitorWorkers,
 				status: latestEvent?.status || "pending",
 				lastCheck: latestEvent

--- a/packages/db/src/migrations/0017_real_colossus.sql
+++ b/packages/db/src/migrations/0017_real_colossus.sql
@@ -1,0 +1,31 @@
+CREATE TABLE "monitor_notification" (
+	"monitor_id" text NOT NULL,
+	"integration_config_id" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "monitor_notification_monitor_id_integration_config_id_pk" PRIMARY KEY("monitor_id","integration_config_id")
+);
+--> statement-breakpoint
+ALTER TABLE "integration_config" ADD COLUMN "name" text;--> statement-breakpoint
+UPDATE "integration_config"
+SET "name" = CASE
+	WHEN "type" = 'webhook' THEN 'Webhook'
+	WHEN "type" = 'discord' THEN 'Discord'
+	WHEN "type" = 'telegram' THEN 'Telegram'
+	WHEN "type" = 'alertmanager' THEN 'Prometheus AlertManager'
+	ELSE "type"
+END
+WHERE "name" IS NULL;--> statement-breakpoint
+ALTER TABLE "integration_config" ALTER COLUMN "name" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "integration_config" ADD COLUMN "is_default" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+UPDATE "integration_config" SET "is_default" = true WHERE "active" = true;--> statement-breakpoint
+ALTER TABLE "monitor_notification" ADD CONSTRAINT "monitor_notification_monitor_id_monitor_id_fk" FOREIGN KEY ("monitor_id") REFERENCES "public"."monitor"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "monitor_notification" ADD CONSTRAINT "monitor_notification_integration_config_id_integration_config_id_fk" FOREIGN KEY ("integration_config_id") REFERENCES "public"."integration_config"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "monitor_notification_monitor_idx" ON "monitor_notification" USING btree ("monitor_id");--> statement-breakpoint
+CREATE INDEX "monitor_notification_config_idx" ON "monitor_notification" USING btree ("integration_config_id");--> statement-breakpoint
+INSERT INTO "monitor_notification" ("monitor_id", "integration_config_id")
+SELECT "monitor"."id", "integration_config"."id"
+FROM "monitor"
+INNER JOIN "integration_config"
+	ON "integration_config"."organization_id" = "monitor"."organization_id"
+WHERE "integration_config"."active" = true
+ON CONFLICT DO NOTHING;

--- a/packages/db/src/migrations/meta/0017_snapshot.json
+++ b/packages/db/src/migrations/meta/0017_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "57cbf7fb-bbab-4bd4-b41e-fff764308718",
-  "prevId": "b8ccf236-b8ce-448c-946e-d7002a16487f",
+  "id": "09d108f9-6cb7-41f8-a18f-3bbe6569bd4e",
+  "prevId": "cdb5bf46-ad88-4787-ac48-0f1374dabc22",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -1526,6 +1526,12 @@
           "primaryKey": false,
           "notNull": true
         },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
         "type": {
           "name": "type",
           "type": "text",
@@ -1544,6 +1550,13 @@
           "primaryKey": false,
           "notNull": true,
           "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
         },
         "created_at": {
           "name": "created_at",
@@ -1608,6 +1621,104 @@
         }
       },
       "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.monitor_notification": {
+      "name": "monitor_notification",
+      "schema": "",
+      "columns": {
+        "monitor_id": {
+          "name": "monitor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_config_id": {
+          "name": "integration_config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "monitor_notification_monitor_idx": {
+          "name": "monitor_notification_monitor_idx",
+          "columns": [
+            {
+              "expression": "monitor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "monitor_notification_config_idx": {
+          "name": "monitor_notification_config_idx",
+          "columns": [
+            {
+              "expression": "integration_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "monitor_notification_monitor_id_monitor_id_fk": {
+          "name": "monitor_notification_monitor_id_monitor_id_fk",
+          "tableFrom": "monitor_notification",
+          "tableTo": "monitor",
+          "columnsFrom": [
+            "monitor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "monitor_notification_integration_config_id_integration_config_id_fk": {
+          "name": "monitor_notification_integration_config_id_integration_config_id_fk",
+          "tableFrom": "monitor_notification",
+          "tableTo": "integration_config",
+          "columnsFrom": [
+            "integration_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "monitor_notification_monitor_id_integration_config_id_pk": {
+          "name": "monitor_notification_monitor_id_integration_config_id_pk",
+          "columns": [
+            "monitor_id",
+            "integration_config_id"
+          ]
+        }
+      },
       "uniqueConstraints": {},
       "policies": {},
       "checkConstraints": {},
@@ -2737,8 +2848,20 @@
         "email": {
           "name": "email",
           "type": "text",
-          "primaryKey": true,
+          "primaryKey": false,
           "notNull": true
+        },
+        "slack_webhook_url": {
+          "name": "slack_webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_webhook_url": {
+          "name": "discord_webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
         },
         "status_page_id": {
           "name": "status_page_id",
@@ -2754,7 +2877,23 @@
           "default": "now()"
         }
       },
-      "indexes": {},
+      "indexes": {
+        "status_page_email_subscribers_page_id_idx": {
+          "name": "status_page_email_subscribers_page_id_idx",
+          "columns": [
+            {
+              "expression": "status_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
       "foreignKeys": {
         "status_page_email_subscribers_status_page_id_status_page_id_fk": {
           "name": "status_page_email_subscribers_status_page_id_status_page_id_fk",
@@ -2770,7 +2909,15 @@
           "onUpdate": "no action"
         }
       },
-      "compositePrimaryKeys": {},
+      "compositePrimaryKeys": {
+        "status_page_email_subscribers_status_page_id_email_pk": {
+          "name": "status_page_email_subscribers_status_page_id_email_pk",
+          "columns": [
+            "status_page_id",
+            "email"
+          ]
+        }
+      },
       "uniqueConstraints": {},
       "policies": {},
       "checkConstraints": {},

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
 			"when": 1775820600000,
 			"tag": "0016_reconcile_schema_state",
 			"breakpoints": true
+		},
+		{
+			"idx": 17,
+			"version": "7",
+			"when": 1777836231512,
+			"tag": "0017_real_colossus",
+			"breakpoints": true
 		}
 	]
 }

--- a/packages/db/src/schema/integrations.ts
+++ b/packages/db/src/schema/integrations.ts
@@ -4,10 +4,12 @@ import {
 	index,
 	json,
 	pgTable,
+	primaryKey,
 	text,
 	timestamp,
 } from "drizzle-orm/pg-core";
 import { organization } from "./auth";
+import { monitor } from "./monitors";
 
 export const integrationConfig = pgTable(
 	"integration_config",
@@ -16,9 +18,11 @@ export const integrationConfig = pgTable(
 		organizationId: text("organization_id")
 			.notNull()
 			.references(() => organization.id, { onDelete: "cascade" }),
+		name: text("name").notNull(),
 		type: text("type").notNull(), // e.g., 'webhook', 'slack', 'discord'
 		config: json("config").$type<Record<string, any>>().notNull(), // Stores the specific config (url, secret, etc.)
 		active: boolean("active").default(true).notNull(),
+		isDefault: boolean("is_default").default(false).notNull(),
 		createdAt: timestamp("created_at").defaultNow().notNull(),
 		updatedAt: timestamp("updated_at")
 			.defaultNow()
@@ -31,12 +35,45 @@ export const integrationConfig = pgTable(
 	],
 );
 
+export const monitorNotification = pgTable(
+	"monitor_notification",
+	{
+		monitorId: text("monitor_id")
+			.notNull()
+			.references(() => monitor.id, { onDelete: "cascade" }),
+		integrationConfigId: text("integration_config_id")
+			.notNull()
+			.references(() => integrationConfig.id, { onDelete: "cascade" }),
+		createdAt: timestamp("created_at").defaultNow().notNull(),
+	},
+	(table) => [
+		primaryKey({ columns: [table.monitorId, table.integrationConfigId] }),
+		index("monitor_notification_monitor_idx").on(table.monitorId),
+		index("monitor_notification_config_idx").on(table.integrationConfigId),
+	],
+);
+
 export const integrationConfigRelations = relations(
 	integrationConfig,
-	({ one }) => ({
+	({ one, many }) => ({
 		organization: one(organization, {
 			fields: [integrationConfig.organizationId],
 			references: [organization.id],
+		}),
+		monitorNotifications: many(monitorNotification),
+	}),
+);
+
+export const monitorNotificationRelations = relations(
+	monitorNotification,
+	({ one }) => ({
+		monitor: one(monitor, {
+			fields: [monitorNotification.monitorId],
+			references: [monitor.id],
+		}),
+		integrationConfig: one(integrationConfig, {
+			fields: [monitorNotification.integrationConfigId],
+			references: [integrationConfig.id],
 		}),
 	}),
 );

--- a/packages/db/src/schema/monitors.ts
+++ b/packages/db/src/schema/monitors.ts
@@ -9,6 +9,7 @@ import {
 	timestamp,
 } from "drizzle-orm/pg-core";
 import { organization } from "./auth";
+import { monitorNotification } from "./integrations";
 import { monitorTag } from "./tags";
 
 export const monitorGroup = pgTable(
@@ -80,6 +81,7 @@ export const monitorRelations = relations(monitor, ({ one, many }) => ({
 		references: [monitorGroup.id],
 	}),
 	monitorTags: many(monitorTag),
+	monitorNotifications: many(monitorNotification),
 }));
 
 export const monitorGroupRelations = relations(


### PR DESCRIPTION
## Summary
- Adds named notification configs with active/default state and monitor assignment rows.
- Updates integrations and monitors APIs for default assignment, exact monitor notification selection, and assignment counts.
- Routes incident delivery through assigned active notifications with default fallback and deduplication.
- Reworks the dashboard integrations area into Notifications and adds notification selection to monitor create/edit.

## Validation
- `bun run db:generate`
- `bunx biome check` on changed TS/TSX files and migration journal
- `bun run check-types` in `packages/db`
- `bun run check-types` in `packages/api`
- `bun run check-types` in `apps/dash`
- `bun test packages/api/src/pkg/integrations/service.test.ts`
- `bun run test`
- `git diff --check`

## Known repo-wide blockers
- Root `bun run check-types` still fails in `packages/auth/src/index.ts:34` with existing Better Auth TS2742 inferred type errors.
- Root `bun run lint` still fails on existing repo-wide Biome diagnostics outside this PR scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned Integrations section as Notifications management with ability to create, configure, test, and remove notifications.
  * Added notification naming and default configuration options for organization-wide use.
  * Enabled assigning notifications to monitors with bulk application to existing monitors.
  * Integrated notification metadata (type, logo) in selection interfaces.
  * Added notification testing with success/error feedback.
  * Displays assigned monitor count and notification status per configured notification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->