### PR TITLE
refactor(types): standardize interface vs type usage

### DIFF
--- a/apps/dash/src/app/(dashboard)/status-pages/[statusPageId]/nav.tsx
+++ b/apps/dash/src/app/(dashboard)/status-pages/[statusPageId]/nav.tsx
@@ -5,11 +5,11 @@ import { usePathname, useRouter } from "next/navigation";
 import { Tabs, TabsList, TabsTab } from "@/components/ui/tabs";
 import { orpc } from "@/utils/orpc";
 
-type NavItem = {
+interface NavItem {
 	title: string;
 	href: string;
 	disabled?: boolean;
-};
+}
 
 const items: NavItem[] = [
 	{

--- a/apps/dash/src/app/(dashboard)/status-pages/[statusPageId]/subscribers/subscribers-table.tsx
+++ b/apps/dash/src/app/(dashboard)/status-pages/[statusPageId]/subscribers/subscribers-table.tsx
@@ -24,18 +24,18 @@ import {
 } from "@/components/ui/table";
 import { orpc } from "@/utils/orpc";
 
-type Subscriber = {
+interface Subscriber {
 	email: string;
 	slackWebhookUrl?: string | null;
 	discordWebhookUrl?: string | null;
 	statusPageId: string;
 	createdAt: Date | string | null;
-};
+}
 
-type SubscribersResponse = {
+interface SubscribersResponse {
 	items: Subscriber[];
 	total: number;
-};
+}
 
 export function SubscribersTable({ statusPageId }: { statusPageId: string }) {
 	const [search, setSearch] = useState("");

--- a/apps/dash/src/components/admin/organizations-table.tsx
+++ b/apps/dash/src/components/admin/organizations-table.tsx
@@ -77,14 +77,14 @@ interface OrganizationRow {
 	regionsPerMonitorLimit: number | null;
 }
 
-type OrganizationFormState = {
+interface OrganizationFormState {
 	activeMonitorLimit: string;
 	logo: string;
 	name: string;
 	ownerEmail: string;
 	regionsPerMonitorLimit: string;
 	slug: string;
-};
+}
 
 const emptyCreateForm: OrganizationFormState = {
 	activeMonitorLimit: "",

--- a/apps/dash/src/components/admin/workers-map.tsx
+++ b/apps/dash/src/components/admin/workers-map.tsx
@@ -20,10 +20,10 @@ interface WorkerRecord {
 	monitorCount: number;
 }
 
-type Coordinates = {
+interface Coordinates {
 	lat: number;
 	lng: number;
-};
+}
 
 const DEFAULT_COORDINATES: Coordinates = { lat: 20, lng: 0 };
 

--- a/apps/dash/src/components/incidents/table.tsx
+++ b/apps/dash/src/components/incidents/table.tsx
@@ -3,73 +3,73 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { formatDistanceToNow } from "date-fns";
 import {
-  ArrowRight,
-  Check,
-  CheckCircle2,
-  ChevronDown,
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  Filter,
-  HelpCircle,
-  Loader2,
-  MoreHorizontal,
-  Plus,
-  Search,
-  ShieldAlert,
-  Trash2,
-  X,
+	ArrowRight,
+	Check,
+	CheckCircle2,
+	ChevronDown,
+	ChevronLeftIcon,
+	ChevronRightIcon,
+	Filter,
+	HelpCircle,
+	Loader2,
+	MoreHorizontal,
+	Plus,
+	Search,
+	ShieldAlert,
+	Trash2,
+	X,
 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import {
-  parseAsInteger,
-  parseAsString,
-  parseAsStringEnum,
-  useQueryStates,
+	parseAsInteger,
+	parseAsString,
+	parseAsStringEnum,
+	useQueryStates,
 } from "nuqs";
 import { useEffect, useState } from "react";
 import { sileo } from "sileo";
 import {
-  AlertDialog,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
+	AlertDialog,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import {
-  Pagination,
-  PaginationContent,
-  PaginationEllipsis,
-  PaginationItem,
+	Pagination,
+	PaginationContent,
+	PaginationEllipsis,
+	PaginationItem,
 } from "@/components/ui/pagination";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
 } from "@/components/ui/select";
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
 } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 import { client, orpc } from "@/utils/orpc";
@@ -81,1164 +81,1164 @@ const INCIDENT_TYPE_FILTERS = ["manual", "automatic"] as const;
 
 type BulkIncidentAction = "acknowledge" | "resolve" | "delete";
 
-type BulkIncidentActionFailure = {
-  id: string;
-  message: string;
-};
+interface BulkIncidentActionFailure {
+	id: string;
+	message: string;
+}
 
-type BulkIncidentActionResult = {
-  succeededIds: string[];
-  failedIds: string[];
-  failedIncidents: BulkIncidentActionFailure[];
-};
+interface BulkIncidentActionResult {
+	succeededIds: string[];
+	failedIds: string[];
+	failedIncidents: BulkIncidentActionFailure[];
+}
 
 function formatIncidentCount(count: number) {
-  return `${count} incident${count === 1 ? "" : "s"}`;
+	return `${count} incident${count === 1 ? "" : "s"}`;
 }
 
 function getErrorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error);
+	return error instanceof Error ? error.message : String(error);
 }
 
 function getBulkActionFailureMessage(
-  failedIncidents: BulkIncidentActionFailure[],
+	failedIncidents: BulkIncidentActionFailure[],
 ) {
-  return failedIncidents
-    .map(({ id, message }) => `${id} (${message})`)
-    .join(", ");
+	return failedIncidents
+		.map(({ id, message }) => `${id} (${message})`)
+		.join(", ");
 }
 
 function getBulkActionResult(
-  ids: string[],
-  results: PromiseSettledResult<string>[],
+	ids: string[],
+	results: PromiseSettledResult<string>[],
 ): BulkIncidentActionResult {
-  return results.reduce<BulkIncidentActionResult>(
-    (result, settledResult, index) => {
-      if (settledResult.status === "fulfilled") {
-        result.succeededIds.push(settledResult.value);
-        return result;
-      }
+	return results.reduce<BulkIncidentActionResult>(
+		(result, settledResult, index) => {
+			if (settledResult.status === "fulfilled") {
+				result.succeededIds.push(settledResult.value);
+				return result;
+			}
 
-      result.failedIds.push(ids[index]);
-      result.failedIncidents.push({
-        id: ids[index],
-        message: getErrorMessage(settledResult.reason),
-      });
+			result.failedIds.push(ids[index]);
+			result.failedIncidents.push({
+				id: ids[index],
+				message: getErrorMessage(settledResult.reason),
+			});
 
-      return result;
-    },
-    { succeededIds: [], failedIds: [], failedIncidents: [] },
-  );
+			return result;
+		},
+		{ succeededIds: [], failedIds: [], failedIncidents: [] },
+	);
 }
 
 function getBulkActionSuccessTitle(action: BulkIncidentAction, count: number) {
-  const incidentCount = formatIncidentCount(count);
+	const incidentCount = formatIncidentCount(count);
 
-  switch (action) {
-    case "acknowledge":
-      return `${incidentCount} acknowledged`;
-    case "resolve":
-      return `${incidentCount} resolved`;
-    case "delete":
-      return `${incidentCount} deleted`;
-  }
+	switch (action) {
+		case "acknowledge":
+			return `${incidentCount} acknowledged`;
+		case "resolve":
+			return `${incidentCount} resolved`;
+		case "delete":
+			return `${incidentCount} deleted`;
+	}
 }
 
 function getBulkActionErrorTitle(action: BulkIncidentAction, message: string) {
-  switch (action) {
-    case "acknowledge":
-      return `Failed to acknowledge incidents: ${message}`;
-    case "resolve":
-      return `Failed to resolve incidents: ${message}`;
-    case "delete":
-      return `Failed to delete incidents: ${message}`;
-  }
+	switch (action) {
+		case "acknowledge":
+			return `Failed to acknowledge incidents: ${message}`;
+		case "resolve":
+			return `Failed to resolve incidents: ${message}`;
+		case "delete":
+			return `Failed to delete incidents: ${message}`;
+	}
 }
 
 export function IncidentsTable() {
-  const router = useRouter();
-  const [searchOpen, setSearchOpen] = useState(false);
-  const [filters, setFilters] = useQueryStates({
-    search: parseAsString.withDefault(""),
-    status: parseAsStringEnum([...INCIDENT_STATUS_FILTERS]),
-    severity: parseAsStringEnum([...INCIDENT_SEVERITY_FILTERS]),
-    type: parseAsStringEnum([...INCIDENT_TYPE_FILTERS]),
-    monitorId: parseAsString,
-    statusPageId: parseAsString,
-    page: parseAsInteger.withDefault(1),
-    pageSize: parseAsStringEnum([...PAGE_SIZE_OPTIONS]).withDefault("25"),
-  });
-  const {
-    search,
-    status: statusFilter,
-    severity: severityFilter,
-    type: typeFilter,
-    monitorId: monitorFilter,
-    statusPageId: statusPageFilter,
-    page: pageParam,
-    pageSize: pageSizeParam,
-  } = filters;
-  const page = Math.max(pageParam, 1);
-  const [selectedIncidentIds, setSelectedIncidentIds] = useState<Set<string>>(
-    () => new Set(),
-  );
-  const [bulkDeleteIds, setBulkDeleteIds] = useState<string[]>([]);
-  const [incidentToDelete, setIncidentToDelete] = useState<{
-    id: string;
-    title: string;
-  } | null>(null);
-  const pageSize = Number(pageSizeParam);
-  const [searchInput, setSearchInput] = useState(search);
-  const [debouncedSearch, setDebouncedSearch] = useState(search);
+	const router = useRouter();
+	const [searchOpen, setSearchOpen] = useState(false);
+	const [filters, setFilters] = useQueryStates({
+		search: parseAsString.withDefault(""),
+		status: parseAsStringEnum([...INCIDENT_STATUS_FILTERS]),
+		severity: parseAsStringEnum([...INCIDENT_SEVERITY_FILTERS]),
+		type: parseAsStringEnum([...INCIDENT_TYPE_FILTERS]),
+		monitorId: parseAsString,
+		statusPageId: parseAsString,
+		page: parseAsInteger.withDefault(1),
+		pageSize: parseAsStringEnum([...PAGE_SIZE_OPTIONS]).withDefault("25"),
+	});
+	const {
+		search,
+		status: statusFilter,
+		severity: severityFilter,
+		type: typeFilter,
+		monitorId: monitorFilter,
+		statusPageId: statusPageFilter,
+		page: pageParam,
+		pageSize: pageSizeParam,
+	} = filters;
+	const page = Math.max(pageParam, 1);
+	const [selectedIncidentIds, setSelectedIncidentIds] = useState<Set<string>>(
+		() => new Set(),
+	);
+	const [bulkDeleteIds, setBulkDeleteIds] = useState<string[]>([]);
+	const [incidentToDelete, setIncidentToDelete] = useState<{
+		id: string;
+		title: string;
+	} | null>(null);
+	const pageSize = Number(pageSizeParam);
+	const [searchInput, setSearchInput] = useState(search);
+	const [debouncedSearch, setDebouncedSearch] = useState(search);
 
-  useEffect(() => {
-    setSearchInput(search);
-  }, [search]);
+	useEffect(() => {
+		setSearchInput(search);
+	}, [search]);
 
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setDebouncedSearch(searchInput);
-      if (searchInput !== search) {
-        void setFilters({
-          search: searchInput || null,
-          page: 1,
-        });
-      }
-    }, 500);
-    return () => clearTimeout(timer);
-  }, [searchInput, setFilters, search]);
+	useEffect(() => {
+		const timer = setTimeout(() => {
+			setDebouncedSearch(searchInput);
+			if (searchInput !== search) {
+				void setFilters({
+					search: searchInput || null,
+					page: 1,
+				});
+			}
+		}, 500);
+		return () => clearTimeout(timer);
+	}, [searchInput, setFilters, search]);
 
-  const { data, isLoading } = useQuery(
-    orpc.incidents.list.queryOptions({
-      input: {
-        status: statusFilter ?? "all",
-        limit: pageSize,
-        offset: (page - 1) * pageSize,
-        q: debouncedSearch || undefined,
-        severity: severityFilter ?? undefined,
-        type: typeFilter ?? undefined,
-        monitorId: monitorFilter ?? undefined,
-        statusPageId: statusPageFilter ?? undefined,
-      },
-    }),
-  );
-  const { data: monitorsData } = useQuery(
-    orpc.monitors.list.queryOptions({ input: { limit: 100 } }),
-  );
-  const { data: statusPagesData } = useQuery(
-    orpc.statusPages.list.queryOptions({ input: { limit: 100 } }),
-  );
+	const { data, isLoading } = useQuery(
+		orpc.incidents.list.queryOptions({
+			input: {
+				status: statusFilter ?? "all",
+				limit: pageSize,
+				offset: (page - 1) * pageSize,
+				q: debouncedSearch || undefined,
+				severity: severityFilter ?? undefined,
+				type: typeFilter ?? undefined,
+				monitorId: monitorFilter ?? undefined,
+				statusPageId: statusPageFilter ?? undefined,
+			},
+		}),
+	);
+	const { data: monitorsData } = useQuery(
+		orpc.monitors.list.queryOptions({ input: { limit: 100 } }),
+	);
+	const { data: statusPagesData } = useQuery(
+		orpc.statusPages.list.queryOptions({ input: { limit: 100 } }),
+	);
 
-  const incidents = data?.items;
-  const monitors = monitorsData?.items ?? [];
-  const statusPages = statusPagesData?.items ?? [];
-  const total = data?.total || 0;
-  const totalPages = Math.ceil(total / pageSize);
-  const currentPageIncidentIds =
-    incidents?.map((incident) => incident.id) ?? [];
-  const selectedIds = Array.from(selectedIncidentIds);
-  const selectedIncidents =
-    incidents?.filter((incident) => selectedIncidentIds.has(incident.id)) ?? [];
-  const selectedOpenIds = selectedIncidents
-    .filter((incident) => !incident.endedAt)
-    .map((incident) => incident.id);
-  const selectedUnacknowledgedOpenIds = selectedIncidents
-    .filter((incident) => !incident.endedAt && !incident.acknowledgedAt)
-    .map((incident) => incident.id);
-  const selectedCount = selectedIds.length;
-  const selectedActionableCount = selectedOpenIds.length;
-  const visibleStart =
-    total === 0 ? 0 : Math.min((page - 1) * pageSize + 1, total);
-  const visibleEnd = total === 0 ? 0 : Math.min(page * pageSize, total);
-  const allCurrentPageSelected =
-    currentPageIncidentIds.length > 0 &&
-    currentPageIncidentIds.every((id) => selectedIncidentIds.has(id));
-  const someCurrentPageSelected =
-    currentPageIncidentIds.length > 0 &&
-    currentPageIncidentIds.some((id) => selectedIncidentIds.has(id));
+	const incidents = data?.items;
+	const monitors = monitorsData?.items ?? [];
+	const statusPages = statusPagesData?.items ?? [];
+	const total = data?.total || 0;
+	const totalPages = Math.ceil(total / pageSize);
+	const currentPageIncidentIds =
+		incidents?.map((incident) => incident.id) ?? [];
+	const selectedIds = Array.from(selectedIncidentIds);
+	const selectedIncidents =
+		incidents?.filter((incident) => selectedIncidentIds.has(incident.id)) ?? [];
+	const selectedOpenIds = selectedIncidents
+		.filter((incident) => !incident.endedAt)
+		.map((incident) => incident.id);
+	const selectedUnacknowledgedOpenIds = selectedIncidents
+		.filter((incident) => !incident.endedAt && !incident.acknowledgedAt)
+		.map((incident) => incident.id);
+	const selectedCount = selectedIds.length;
+	const selectedActionableCount = selectedOpenIds.length;
+	const visibleStart =
+		total === 0 ? 0 : Math.min((page - 1) * pageSize + 1, total);
+	const visibleEnd = total === 0 ? 0 : Math.min(page * pageSize, total);
+	const allCurrentPageSelected =
+		currentPageIncidentIds.length > 0 &&
+		currentPageIncidentIds.every((id) => selectedIncidentIds.has(id));
+	const someCurrentPageSelected =
+		currentPageIncidentIds.length > 0 &&
+		currentPageIncidentIds.some((id) => selectedIncidentIds.has(id));
 
-  const queryClient = useQueryClient();
+	const queryClient = useQueryClient();
 
-  const { mutate: deleteIncident, isPending: isDeleting } = useMutation({
-    mutationFn: (id: string) => client.incidents.delete({ id }),
-    onSuccess: (_data, id) => {
-      sileo.success({ title: "Incident deleted" });
-      queryClient.invalidateQueries({ queryKey: orpc.incidents.list.key() });
-      setSelectedIncidentIds((previous) => {
-        const next = new Set(previous);
-        next.delete(id);
-        return next;
-      });
-      setIncidentToDelete(null);
-    },
-    onError: (err) => {
-      sileo.error({ title: `Failed to delete incident: ${err.message}` });
-      setIncidentToDelete(null);
-    },
-  });
+	const { mutate: deleteIncident, isPending: isDeleting } = useMutation({
+		mutationFn: (id: string) => client.incidents.delete({ id }),
+		onSuccess: (_data, id) => {
+			sileo.success({ title: "Incident deleted" });
+			queryClient.invalidateQueries({ queryKey: orpc.incidents.list.key() });
+			setSelectedIncidentIds((previous) => {
+				const next = new Set(previous);
+				next.delete(id);
+				return next;
+			});
+			setIncidentToDelete(null);
+		},
+		onError: (err) => {
+			sileo.error({ title: `Failed to delete incident: ${err.message}` });
+			setIncidentToDelete(null);
+		},
+	});
 
-  const bulkIncidentAction = useMutation({
-    mutationFn: async ({
-      action,
-      ids,
-    }: {
-      action: BulkIncidentAction;
-      ids: string[];
-    }) => {
-      if (action === "acknowledge") {
-        const results = await Promise.allSettled(
-          ids.map(async (id) => {
-            await client.incidents.acknowledge({ id });
-            return id;
-          }),
-        );
+	const bulkIncidentAction = useMutation({
+		mutationFn: async ({
+			action,
+			ids,
+		}: {
+			action: BulkIncidentAction;
+			ids: string[];
+		}) => {
+			if (action === "acknowledge") {
+				const results = await Promise.allSettled(
+					ids.map(async (id) => {
+						await client.incidents.acknowledge({ id });
+						return id;
+					}),
+				);
 
-        return getBulkActionResult(ids, results);
-      }
+				return getBulkActionResult(ids, results);
+			}
 
-      if (action === "resolve") {
-        const results = await Promise.allSettled(
-          ids.map(async (id) => {
-            await client.incidents.resolve({ id });
-            return id;
-          }),
-        );
+			if (action === "resolve") {
+				const results = await Promise.allSettled(
+					ids.map(async (id) => {
+						await client.incidents.resolve({ id });
+						return id;
+					}),
+				);
 
-        return getBulkActionResult(ids, results);
-      }
+				return getBulkActionResult(ids, results);
+			}
 
-      const results = await Promise.allSettled(
-        ids.map(async (id) => {
-          await client.incidents.delete({ id });
-          return id;
-        }),
-      );
+			const results = await Promise.allSettled(
+				ids.map(async (id) => {
+					await client.incidents.delete({ id });
+					return id;
+				}),
+			);
 
-      return getBulkActionResult(ids, results);
-    },
-    onError: (err, { action, ids }) => {
-      sileo.error({
-        title: getBulkActionErrorTitle(
-          action,
-          getBulkActionFailureMessage(
-            ids.map((id) => ({ id, message: getErrorMessage(err) })),
-          ),
-        ),
-      });
-    },
-    onSettled: (data, _error, { action }) => {
-      if (data) {
-        const succeededIdSet = new Set(data.succeededIds);
+			return getBulkActionResult(ids, results);
+		},
+		onError: (err, { action, ids }) => {
+			sileo.error({
+				title: getBulkActionErrorTitle(
+					action,
+					getBulkActionFailureMessage(
+						ids.map((id) => ({ id, message: getErrorMessage(err) })),
+					),
+				),
+			});
+		},
+		onSettled: (data, _error, { action }) => {
+			if (data) {
+				const succeededIdSet = new Set(data.succeededIds);
 
-        if (data.succeededIds.length > 0) {
-          sileo.success({
-            title: getBulkActionSuccessTitle(action, data.succeededIds.length),
-          });
-          setSelectedIncidentIds((previous) => {
-            const next = new Set(previous);
+				if (data.succeededIds.length > 0) {
+					sileo.success({
+						title: getBulkActionSuccessTitle(action, data.succeededIds.length),
+					});
+					setSelectedIncidentIds((previous) => {
+						const next = new Set(previous);
 
-            for (const id of succeededIdSet) {
-              next.delete(id);
-            }
+						for (const id of succeededIdSet) {
+							next.delete(id);
+						}
 
-            return next;
-          });
-          setBulkDeleteIds((previous) =>
-            previous.filter((id) => !succeededIdSet.has(id)),
-          );
-        }
+						return next;
+					});
+					setBulkDeleteIds((previous) =>
+						previous.filter((id) => !succeededIdSet.has(id)),
+					);
+				}
 
-        if (data.failedIds.length > 0) {
-          sileo.error({
-            title: getBulkActionErrorTitle(
-              action,
-              getBulkActionFailureMessage(data.failedIncidents),
-            ),
-          });
-        }
-      }
+				if (data.failedIds.length > 0) {
+					sileo.error({
+						title: getBulkActionErrorTitle(
+							action,
+							getBulkActionFailureMessage(data.failedIncidents),
+						),
+					});
+				}
+			}
 
-      queryClient.invalidateQueries({ queryKey: orpc.incidents.list.key() });
-    },
-  });
+			queryClient.invalidateQueries({ queryKey: orpc.incidents.list.key() });
+		},
+	});
 
-  useEffect(() => {
-    if (!incidents) {
-      return;
-    }
+	useEffect(() => {
+		if (!incidents) {
+			return;
+		}
 
-    const currentPageIds = new Set(incidents.map((incident) => incident.id));
+		const currentPageIds = new Set(incidents.map((incident) => incident.id));
 
-    setSelectedIncidentIds((previous) => {
-      const next = new Set(
-        Array.from(previous).filter((id) => currentPageIds.has(id)),
-      );
+		setSelectedIncidentIds((previous) => {
+			const next = new Set(
+				Array.from(previous).filter((id) => currentPageIds.has(id)),
+			);
 
-      return next.size === previous.size ? previous : next;
-    });
-  }, [incidents]);
+			return next.size === previous.size ? previous : next;
+		});
+	}, [incidents]);
 
-  useEffect(() => {
-    setSelectedIncidentIds(new Set());
-  }, [
-    debouncedSearch,
-    statusFilter,
-    severityFilter,
-    typeFilter,
-    monitorFilter,
-    statusPageFilter,
-    page,
-    pageSize,
-  ]);
+	useEffect(() => {
+		setSelectedIncidentIds(new Set());
+	}, [
+		debouncedSearch,
+		statusFilter,
+		severityFilter,
+		typeFilter,
+		monitorFilter,
+		statusPageFilter,
+		page,
+		pageSize,
+	]);
 
-  useEffect(() => {
-    if (totalPages > 0 && page > totalPages) {
-      void setFilters({ page: totalPages });
-    }
-  }, [page, setFilters, totalPages]);
+	useEffect(() => {
+		if (totalPages > 0 && page > totalPages) {
+			void setFilters({ page: totalPages });
+		}
+	}, [page, setFilters, totalPages]);
 
-  const getStatusIcon = (status: string) => {
-    switch (status) {
-      case "resolved":
-        return <CheckCircle2 className="h-5 w-5 text-emerald-500" />;
-      case "investigating":
-      case "identified":
-      case "monitoring":
-        return <ShieldAlert className="h-5 w-5 text-red-500" />;
-      default:
-        return <HelpCircle className="h-5 w-5 text-muted-foreground" />;
-    }
-  };
+	const getStatusIcon = (status: string) => {
+		switch (status) {
+			case "resolved":
+				return <CheckCircle2 className="h-5 w-5 text-emerald-500" />;
+			case "investigating":
+			case "identified":
+			case "monitoring":
+				return <ShieldAlert className="h-5 w-5 text-red-500" />;
+			default:
+				return <HelpCircle className="h-5 w-5 text-muted-foreground" />;
+		}
+	};
 
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case "resolved":
-        return "border-emerald-500/20 bg-emerald-500/10 text-emerald-500";
-      case "investigating":
-      case "identified":
-      case "monitoring":
-        return "border-red-500/20 bg-red-500/10 text-red-500";
-      default:
-        return "border-muted bg-muted/50 text-muted-foreground";
-    }
-  };
+	const getStatusColor = (status: string) => {
+		switch (status) {
+			case "resolved":
+				return "border-emerald-500/20 bg-emerald-500/10 text-emerald-500";
+			case "investigating":
+			case "identified":
+			case "monitoring":
+				return "border-red-500/20 bg-red-500/10 text-red-500";
+			default:
+				return "border-muted bg-muted/50 text-muted-foreground";
+		}
+	};
 
-  const clearSelection = () => {
-    setSelectedIncidentIds(new Set());
-  };
+	const clearSelection = () => {
+		setSelectedIncidentIds(new Set());
+	};
 
-  const toggleIncidentSelection = (id: string, checked: boolean) => {
-    setSelectedIncidentIds((previous) => {
-      const next = new Set(previous);
+	const toggleIncidentSelection = (id: string, checked: boolean) => {
+		setSelectedIncidentIds((previous) => {
+			const next = new Set(previous);
 
-      if (checked) {
-        next.add(id);
-      } else {
-        next.delete(id);
-      }
+			if (checked) {
+				next.add(id);
+			} else {
+				next.delete(id);
+			}
 
-      return next;
-    });
-  };
+			return next;
+		});
+	};
 
-  const toggleCurrentPageSelection = (checked: boolean) => {
-    setSelectedIncidentIds(
-      checked ? new Set(currentPageIncidentIds) : new Set(),
-    );
-  };
+	const toggleCurrentPageSelection = (checked: boolean) => {
+		setSelectedIncidentIds(
+			checked ? new Set(currentPageIncidentIds) : new Set(),
+		);
+	};
 
-  const runBulkAction = (action: BulkIncidentAction, ids: string[]) => {
-    if (ids.length === 0) {
-      return;
-    }
+	const runBulkAction = (action: BulkIncidentAction, ids: string[]) => {
+		if (ids.length === 0) {
+			return;
+		}
 
-    bulkIncidentAction.mutate({ action, ids });
-  };
+		bulkIncidentAction.mutate({ action, ids });
+	};
 
-  const clearFilters = () => {
-    setSearchInput("");
-    void setFilters({
-      search: null,
-      status: null,
-      severity: null,
-      type: null,
-      monitorId: null,
-      statusPageId: null,
-      page: 1,
-    });
-    clearSelection();
-  };
+	const clearFilters = () => {
+		setSearchInput("");
+		void setFilters({
+			search: null,
+			status: null,
+			severity: null,
+			type: null,
+			monitorId: null,
+			statusPageId: null,
+			page: 1,
+		});
+		clearSelection();
+	};
 
-  const activeFilterCount = [
-    statusFilter !== null,
-    severityFilter !== null,
-    typeFilter !== null,
-    monitorFilter !== null,
-    statusPageFilter !== null,
-  ].filter(Boolean).length;
+	const activeFilterCount = [
+		statusFilter !== null,
+		severityFilter !== null,
+		typeFilter !== null,
+		monitorFilter !== null,
+		statusPageFilter !== null,
+	].filter(Boolean).length;
 
-  return (
-    <div className="mx-auto w-full max-w-6xl space-y-4">
-      <Dialog open={searchOpen} onOpenChange={setSearchOpen}>
-        <DialogContent className="flex items-center justify-center border-none bg-transparent p-0 shadow-none sm:max-w-[425px]">
-          <DialogTitle className="sr-only">Search</DialogTitle>
-          <div className="relative w-full">
-            <Input
-              autoFocus
-              placeholder="Search incidents..."
-              className="h-12 rounded-full border-muted bg-background pr-12 pl-6 shadow-lg"
-              value={searchInput}
-              onChange={(e) => setSearchInput(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  setSearchOpen(false);
-                }
-              }}
-            />
-            <Button
-              size="icon"
-              className="absolute top-1 right-1 h-10 w-10 rounded-full"
-              onClick={() => setSearchOpen(false)}
-            >
-              <ArrowRight className="h-4 w-4" />
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
-      <div className="flex items-center justify-between gap-4">
-        <h1 className="font-bold text-2xl tracking-tight">Incidents</h1>
-        <div className="flex items-center gap-2">
-          <div className="relative hidden w-64 md:block">
-            <Search className="absolute top-2.5 left-2 h-4 w-4 text-muted-foreground" />
-            <Input
-              placeholder="Search incidents..."
-              className="pl-8"
-              value={searchInput}
-              onChange={(e) => setSearchInput(e.target.value)}
-            />
-          </div>
-          <Button
-            variant="outline"
-            size="icon"
-            className="relative md:hidden"
-            onClick={() => setSearchOpen(true)}
-          >
-            <Search className="h-4 w-4" />
-            {search && (
-              <span className="absolute -top-1 -right-1 flex h-3 w-3 items-center justify-center rounded-full bg-primary" />
-            )}
-          </Button>
-          <DropdownMenu modal={false}>
-            <DropdownMenuTrigger
-              render={
-                <Button variant="outline" size="icon" className="relative" />
-              }
-            >
-              <Filter className="h-4 w-4" />
-              {activeFilterCount > 0 && (
-                <span className="absolute -top-1 -right-1 flex h-3 w-3 items-center justify-center rounded-full bg-primary text-[8px] text-primary-foreground">
-                  {activeFilterCount}
-                </span>
-              )}
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-56 p-2">
-              <div className="mb-2 px-2 font-semibold text-muted-foreground text-xs uppercase">
-                Status
-              </div>
-              <DropdownMenuItem
-                onClick={() => {
-                  void setFilters({ status: null, page: 1 });
-                }}
-                className="flex justify-between"
-              >
-                All Statuses
-                {statusFilter === null && <Check className="h-4 w-4" />}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() => {
-                  void setFilters({ status: "open", page: 1 });
-                }}
-                className="flex justify-between"
-              >
-                Open
-                {statusFilter === "open" && <Check className="h-4 w-4" />}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() => {
-                  void setFilters({ status: "resolved", page: 1 });
-                }}
-                className="flex justify-between"
-              >
-                Resolved
-                {statusFilter === "resolved" && <Check className="h-4 w-4" />}
-              </DropdownMenuItem>
+	return (
+		<div className="mx-auto w-full max-w-6xl space-y-4">
+			<Dialog open={searchOpen} onOpenChange={setSearchOpen}>
+				<DialogContent className="flex items-center justify-center border-none bg-transparent p-0 shadow-none sm:max-w-[425px]">
+					<DialogTitle className="sr-only">Search</DialogTitle>
+					<div className="relative w-full">
+						<Input
+							autoFocus
+							placeholder="Search incidents..."
+							className="h-12 rounded-full border-muted bg-background pr-12 pl-6 shadow-lg"
+							value={searchInput}
+							onChange={(e) => setSearchInput(e.target.value)}
+							onKeyDown={(e) => {
+								if (e.key === "Enter") {
+									setSearchOpen(false);
+								}
+							}}
+						/>
+						<Button
+							size="icon"
+							className="absolute top-1 right-1 h-10 w-10 rounded-full"
+							onClick={() => setSearchOpen(false)}
+						>
+							<ArrowRight className="h-4 w-4" />
+						</Button>
+					</div>
+				</DialogContent>
+			</Dialog>
+			<div className="flex items-center justify-between gap-4">
+				<h1 className="font-bold text-2xl tracking-tight">Incidents</h1>
+				<div className="flex items-center gap-2">
+					<div className="relative hidden w-64 md:block">
+						<Search className="absolute top-2.5 left-2 h-4 w-4 text-muted-foreground" />
+						<Input
+							placeholder="Search incidents..."
+							className="pl-8"
+							value={searchInput}
+							onChange={(e) => setSearchInput(e.target.value)}
+						/>
+					</div>
+					<Button
+						variant="outline"
+						size="icon"
+						className="relative md:hidden"
+						onClick={() => setSearchOpen(true)}
+					>
+						<Search className="h-4 w-4" />
+						{search && (
+							<span className="absolute -top-1 -right-1 flex h-3 w-3 items-center justify-center rounded-full bg-primary" />
+						)}
+					</Button>
+					<DropdownMenu modal={false}>
+						<DropdownMenuTrigger
+							render={
+								<Button variant="outline" size="icon" className="relative" />
+							}
+						>
+							<Filter className="h-4 w-4" />
+							{activeFilterCount > 0 && (
+								<span className="absolute -top-1 -right-1 flex h-3 w-3 items-center justify-center rounded-full bg-primary text-[8px] text-primary-foreground">
+									{activeFilterCount}
+								</span>
+							)}
+						</DropdownMenuTrigger>
+						<DropdownMenuContent align="end" className="w-56 p-2">
+							<div className="mb-2 px-2 font-semibold text-muted-foreground text-xs uppercase">
+								Status
+							</div>
+							<DropdownMenuItem
+								onClick={() => {
+									void setFilters({ status: null, page: 1 });
+								}}
+								className="flex justify-between"
+							>
+								All Statuses
+								{statusFilter === null && <Check className="h-4 w-4" />}
+							</DropdownMenuItem>
+							<DropdownMenuItem
+								onClick={() => {
+									void setFilters({ status: "open", page: 1 });
+								}}
+								className="flex justify-between"
+							>
+								Open
+								{statusFilter === "open" && <Check className="h-4 w-4" />}
+							</DropdownMenuItem>
+							<DropdownMenuItem
+								onClick={() => {
+									void setFilters({ status: "resolved", page: 1 });
+								}}
+								className="flex justify-between"
+							>
+								Resolved
+								{statusFilter === "resolved" && <Check className="h-4 w-4" />}
+							</DropdownMenuItem>
 
-              <div className="my-2 h-px bg-muted" />
+							<div className="my-2 h-px bg-muted" />
 
-              <div className="mb-2 px-2 font-semibold text-muted-foreground text-xs uppercase">
-                Severity
-              </div>
-              <DropdownMenuItem
-                onClick={() => {
-                  void setFilters({ severity: null, page: 1 });
-                }}
-                className="flex justify-between"
-              >
-                All Severities
-                {!severityFilter && <Check className="h-4 w-4" />}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() => {
-                  void setFilters({ severity: "minor", page: 1 });
-                }}
-                className="flex justify-between"
-              >
-                Minor
-                {severityFilter === "minor" && <Check className="h-4 w-4" />}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() => {
-                  void setFilters({ severity: "major", page: 1 });
-                }}
-                className="flex justify-between"
-              >
-                Major
-                {severityFilter === "major" && <Check className="h-4 w-4" />}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() => {
-                  void setFilters({ severity: "critical", page: 1 });
-                }}
-                className="flex justify-between"
-              >
-                Critical
-                {severityFilter === "critical" && <Check className="h-4 w-4" />}
-              </DropdownMenuItem>
+							<div className="mb-2 px-2 font-semibold text-muted-foreground text-xs uppercase">
+								Severity
+							</div>
+							<DropdownMenuItem
+								onClick={() => {
+									void setFilters({ severity: null, page: 1 });
+								}}
+								className="flex justify-between"
+							>
+								All Severities
+								{!severityFilter && <Check className="h-4 w-4" />}
+							</DropdownMenuItem>
+							<DropdownMenuItem
+								onClick={() => {
+									void setFilters({ severity: "minor", page: 1 });
+								}}
+								className="flex justify-between"
+							>
+								Minor
+								{severityFilter === "minor" && <Check className="h-4 w-4" />}
+							</DropdownMenuItem>
+							<DropdownMenuItem
+								onClick={() => {
+									void setFilters({ severity: "major", page: 1 });
+								}}
+								className="flex justify-between"
+							>
+								Major
+								{severityFilter === "major" && <Check className="h-4 w-4" />}
+							</DropdownMenuItem>
+							<DropdownMenuItem
+								onClick={() => {
+									void setFilters({ severity: "critical", page: 1 });
+								}}
+								className="flex justify-between"
+							>
+								Critical
+								{severityFilter === "critical" && <Check className="h-4 w-4" />}
+							</DropdownMenuItem>
 
-              <div className="my-2 h-px bg-muted" />
+							<div className="my-2 h-px bg-muted" />
 
-              <div className="mb-2 px-2 font-semibold text-muted-foreground text-xs uppercase">
-                Type
-              </div>
-              <DropdownMenuItem
-                onClick={() => {
-                  void setFilters({ type: null, page: 1 });
-                }}
-                className="flex justify-between"
-              >
-                All Types
-                {!typeFilter && <Check className="h-4 w-4" />}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() => {
-                  void setFilters({ type: "manual", page: 1 });
-                }}
-                className="flex justify-between"
-              >
-                Manual
-                {typeFilter === "manual" && <Check className="h-4 w-4" />}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() => {
-                  void setFilters({ type: "automatic", page: 1 });
-                }}
-                className="flex justify-between"
-              >
-                Automatic
-                {typeFilter === "automatic" && <Check className="h-4 w-4" />}
-              </DropdownMenuItem>
+							<div className="mb-2 px-2 font-semibold text-muted-foreground text-xs uppercase">
+								Type
+							</div>
+							<DropdownMenuItem
+								onClick={() => {
+									void setFilters({ type: null, page: 1 });
+								}}
+								className="flex justify-between"
+							>
+								All Types
+								{!typeFilter && <Check className="h-4 w-4" />}
+							</DropdownMenuItem>
+							<DropdownMenuItem
+								onClick={() => {
+									void setFilters({ type: "manual", page: 1 });
+								}}
+								className="flex justify-between"
+							>
+								Manual
+								{typeFilter === "manual" && <Check className="h-4 w-4" />}
+							</DropdownMenuItem>
+							<DropdownMenuItem
+								onClick={() => {
+									void setFilters({ type: "automatic", page: 1 });
+								}}
+								className="flex justify-between"
+							>
+								Automatic
+								{typeFilter === "automatic" && <Check className="h-4 w-4" />}
+							</DropdownMenuItem>
 
-              <div className="my-2 h-px bg-muted" />
+							<div className="my-2 h-px bg-muted" />
 
-              <div className="mb-2 px-2 font-semibold text-muted-foreground text-xs uppercase">
-                Affected Monitor
-              </div>
-              <DropdownMenuItem
-                onClick={() => {
-                  void setFilters({ monitorId: null, page: 1 });
-                }}
-                className="flex justify-between"
-              >
-                All Monitors
-                {monitorFilter === null && <Check className="h-4 w-4" />}
-              </DropdownMenuItem>
-              {monitors.map((monitor) => (
-                <DropdownMenuItem
-                  key={monitor.id}
-                  onClick={() => {
-                    void setFilters({ monitorId: monitor.id, page: 1 });
-                  }}
-                  className="flex justify-between gap-2"
-                >
-                  <span className="truncate">{monitor.name}</span>
-                  {monitorFilter === monitor.id && (
-                    <Check className="h-4 w-4" />
-                  )}
-                </DropdownMenuItem>
-              ))}
+							<div className="mb-2 px-2 font-semibold text-muted-foreground text-xs uppercase">
+								Affected Monitor
+							</div>
+							<DropdownMenuItem
+								onClick={() => {
+									void setFilters({ monitorId: null, page: 1 });
+								}}
+								className="flex justify-between"
+							>
+								All Monitors
+								{monitorFilter === null && <Check className="h-4 w-4" />}
+							</DropdownMenuItem>
+							{monitors.map((monitor) => (
+								<DropdownMenuItem
+									key={monitor.id}
+									onClick={() => {
+										void setFilters({ monitorId: monitor.id, page: 1 });
+									}}
+									className="flex justify-between gap-2"
+								>
+									<span className="truncate">{monitor.name}</span>
+									{monitorFilter === monitor.id && (
+										<Check className="h-4 w-4" />
+									)}
+								</DropdownMenuItem>
+							))}
 
-              <div className="my-2 h-px bg-muted" />
+							<div className="my-2 h-px bg-muted" />
 
-              <div className="mb-2 px-2 font-semibold text-muted-foreground text-xs uppercase">
-                Status Page
-              </div>
-              <DropdownMenuItem
-                onClick={() => {
-                  void setFilters({ statusPageId: null, page: 1 });
-                }}
-                className="flex justify-between"
-              >
-                All Status Pages
-                {statusPageFilter === null && <Check className="h-4 w-4" />}
-              </DropdownMenuItem>
-              {statusPages.map((statusPage) => (
-                <DropdownMenuItem
-                  key={statusPage.id}
-                  onClick={() => {
-                    void setFilters({
-                      statusPageId: statusPage.id,
-                      page: 1,
-                    });
-                  }}
-                  className="flex justify-between gap-2"
-                >
-                  <span className="truncate">{statusPage.name}</span>
-                  {statusPageFilter === statusPage.id && (
-                    <Check className="h-4 w-4" />
-                  )}
-                </DropdownMenuItem>
-              ))}
+							<div className="mb-2 px-2 font-semibold text-muted-foreground text-xs uppercase">
+								Status Page
+							</div>
+							<DropdownMenuItem
+								onClick={() => {
+									void setFilters({ statusPageId: null, page: 1 });
+								}}
+								className="flex justify-between"
+							>
+								All Status Pages
+								{statusPageFilter === null && <Check className="h-4 w-4" />}
+							</DropdownMenuItem>
+							{statusPages.map((statusPage) => (
+								<DropdownMenuItem
+									key={statusPage.id}
+									onClick={() => {
+										void setFilters({
+											statusPageId: statusPage.id,
+											page: 1,
+										});
+									}}
+									className="flex justify-between gap-2"
+								>
+									<span className="truncate">{statusPage.name}</span>
+									{statusPageFilter === statusPage.id && (
+										<Check className="h-4 w-4" />
+									)}
+								</DropdownMenuItem>
+							))}
 
-              <div className="my-2 h-px bg-muted" />
+							<div className="my-2 h-px bg-muted" />
 
-              <div className="mb-2 px-2 font-semibold text-muted-foreground text-xs uppercase">
-                Page Size
-              </div>
-              {/** biome-ignore lint/a11y/noStaticElementInteractions: keep Select interactions inside the filter menu */}
-              {/** biome-ignore lint/a11y/useKeyWithClickEvents: Select handles keyboard interaction */}
-              <div
-                className="px-2"
-                onClick={(e) => e.stopPropagation()}
-                onPointerDown={(e) => e.stopPropagation()}
-              >
-                <Select
-                  value={pageSizeParam}
-                  onValueChange={(value) => {
-                    void setFilters({
-                      pageSize: value as (typeof PAGE_SIZE_OPTIONS)[number],
-                      page: 1,
-                    });
-                  }}
-                >
-                  <SelectTrigger
-                    className="h-8 w-full"
-                    onPointerDown={(e) => e.stopPropagation()}
-                  >
-                    <SelectValue placeholder="Page size">
-                      {pageSize} per page
-                    </SelectValue>
-                  </SelectTrigger>
-                  <SelectContent>
-                    {PAGE_SIZE_OPTIONS.map((size) => (
-                      <SelectItem key={size} value={size}>
-                        {size} per page
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
+							<div className="mb-2 px-2 font-semibold text-muted-foreground text-xs uppercase">
+								Page Size
+							</div>
+							{/** biome-ignore lint/a11y/noStaticElementInteractions: keep Select interactions inside the filter menu */}
+							{/** biome-ignore lint/a11y/useKeyWithClickEvents: Select handles keyboard interaction */}
+							<div
+								className="px-2"
+								onClick={(e) => e.stopPropagation()}
+								onPointerDown={(e) => e.stopPropagation()}
+							>
+								<Select
+									value={pageSizeParam}
+									onValueChange={(value) => {
+										void setFilters({
+											pageSize: value as (typeof PAGE_SIZE_OPTIONS)[number],
+											page: 1,
+										});
+									}}
+								>
+									<SelectTrigger
+										className="h-8 w-full"
+										onPointerDown={(e) => e.stopPropagation()}
+									>
+										<SelectValue placeholder="Page size">
+											{pageSize} per page
+										</SelectValue>
+									</SelectTrigger>
+									<SelectContent>
+										{PAGE_SIZE_OPTIONS.map((size) => (
+											<SelectItem key={size} value={size}>
+												{size} per page
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							</div>
 
-              {activeFilterCount > 0 && (
-                <>
-                  <div className="my-2 h-px bg-muted" />
-                  <DropdownMenuItem
-                    onClick={clearFilters}
-                    className="justify-center text-red-500 hover:text-red-600"
-                  >
-                    Clear filters
-                  </DropdownMenuItem>
-                </>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-          <Button
-            className="w-9 gap-2 border-none bg-white p-0 text-black shadow-md shadow-white/10 hover:bg-gray-100 md:w-auto md:px-4"
-            render={
-              <Link href="/incidents/new">
-                <Plus className="h-4 w-4" />
-                <span className="hidden md:inline">Report a new incident</span>
-              </Link>
-            }
-          />
-        </div>
-      </div>
+							{activeFilterCount > 0 && (
+								<>
+									<div className="my-2 h-px bg-muted" />
+									<DropdownMenuItem
+										onClick={clearFilters}
+										className="justify-center text-red-500 hover:text-red-600"
+									>
+										Clear filters
+									</DropdownMenuItem>
+								</>
+							)}
+						</DropdownMenuContent>
+					</DropdownMenu>
+					<Button
+						className="w-9 gap-2 border-none bg-white p-0 text-black shadow-md shadow-white/10 hover:bg-gray-100 md:w-auto md:px-4"
+						render={
+							<Link href="/incidents/new">
+								<Plus className="h-4 w-4" />
+								<span className="hidden md:inline">Report a new incident</span>
+							</Link>
+						}
+					/>
+				</div>
+			</div>
 
-      <div className="overflow-hidden rounded-xl border bg-card shadow-sm">
-        <div className="flex min-h-12 flex-col gap-3 border-b bg-muted/20 px-4 py-3 lg:flex-row lg:items-center lg:justify-between">
-          <div className="flex items-center gap-3 font-medium text-muted-foreground text-sm">
-            {currentPageIncidentIds.length > 0 ? (
-              <Checkbox
-                aria-label={
-                  allCurrentPageSelected
-                    ? "Deselect all incidents on this page"
-                    : "Select all incidents on this page"
-                }
-                checked={allCurrentPageSelected}
-                indeterminate={
-                  someCurrentPageSelected && !allCurrentPageSelected
-                }
-                onCheckedChange={(checked) =>
-                  toggleCurrentPageSelection(checked === true)
-                }
-              />
-            ) : (
-              <ChevronDown className="h-4 w-4" />
-            )}
-            <span>Incidents</span>
-            {total > 0 && (
-              <Badge className="rounded-full bg-muted px-2 py-0.5 text-muted-foreground text-xs">
-                {visibleStart}-{visibleEnd} of {total}
-              </Badge>
-            )}
-          </div>
-          {selectedCount > 0 && (
-            <div className="flex min-h-7 flex-wrap items-center gap-2 transition-opacity lg:justify-end">
-              <span className="mr-1 whitespace-nowrap font-medium text-foreground text-sm">
-                {formatIncidentCount(selectedCount)} selected
-              </span>
-              <span className="hidden text-muted-foreground text-xs sm:inline">
-                {selectedActionableCount > 0
-                  ? `${formatIncidentCount(selectedActionableCount)} can be updated`
-                  : "Only delete is available for this selection"}
-              </span>
-              <Button
-                variant="outline"
-                size="xs"
-                onClick={() =>
-                  runBulkAction("acknowledge", selectedUnacknowledgedOpenIds)
-                }
-                disabled={
-                  bulkIncidentAction.isPending ||
-                  selectedUnacknowledgedOpenIds.length === 0
-                }
-              >
-                <Check className="h-4 w-4" />
-                <span className="hidden sm:inline">
-                  Acknowledge
-                  {selectedUnacknowledgedOpenIds.length > 0
-                    ? ` (${selectedUnacknowledgedOpenIds.length})`
-                    : ""}
-                </span>
-              </Button>
-              <Button
-                variant="outline"
-                size="xs"
-                onClick={() => runBulkAction("resolve", selectedOpenIds)}
-                disabled={
-                  bulkIncidentAction.isPending || selectedOpenIds.length === 0
-                }
-              >
-                <CheckCircle2 className="h-4 w-4" />
-                <span className="hidden sm:inline">
-                  Resolve
-                  {selectedOpenIds.length > 0
-                    ? ` (${selectedOpenIds.length})`
-                    : ""}
-                </span>
-              </Button>
-              <Button
-                variant="destructive-outline"
-                size="xs"
-                onClick={() => setBulkDeleteIds(selectedIds)}
-                disabled={bulkIncidentAction.isPending}
-              >
-                <Trash2 className="h-4 w-4" />
-                <span className="hidden sm:inline">Delete</span>
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                aria-label="Clear selection"
-                onClick={clearSelection}
-                disabled={bulkIncidentAction.isPending}
-              >
-                <X className="h-4 w-4" />
-              </Button>
-            </div>
-          )}
-        </div>
-        <Table>
-          <TableHeader>
-            <TableRow className="hover:bg-transparent">
-              <TableHead className="w-12 pr-0 pl-4">
-                <span className="sr-only">Select</span>
-              </TableHead>
-              <TableHead className="min-w-[280px] pl-2">Incident</TableHead>
-              <TableHead className="w-[150px]">Started</TableHead>
-              <TableHead className="w-[150px]">Status</TableHead>
-              <TableHead className="w-[52px] pr-4 text-right">
-                <span className="sr-only">Actions</span>
-              </TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {isLoading ? (
-              <TableRow>
-                <TableCell colSpan={5} className="h-24 text-center">
-                  <Loader2 className="mx-auto h-6 w-6 animate-spin text-muted-foreground" />
-                </TableCell>
-              </TableRow>
-            ) : !incidents || incidents.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={5} className="h-24 text-center">
-                  <div className="flex flex-col items-center justify-center gap-2 py-6">
-                    <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted/50">
-                      <ShieldAlert className="h-6 w-6 text-muted-foreground" />
-                    </div>
-                    <p className="font-medium text-lg">No incidents found</p>
-                    <p className="text-muted-foreground text-sm">
-                      {search ||
-                      statusFilter !== null ||
-                      severityFilter ||
-                      typeFilter ||
-                      monitorFilter ||
-                      statusPageFilter
-                        ? "Try adjusting your filters"
-                        : "Get started by creating your first incident."}
-                    </p>
-                    {!search &&
-                      statusFilter === null &&
-                      !severityFilter &&
-                      !typeFilter &&
-                      !monitorFilter &&
-                      !statusPageFilter && (
-                        <div className="mt-2">
-                          <Button
-                            render={
-                              <Link href="/incidents/new">Create incident</Link>
-                            }
-                          />
-                        </div>
-                      )}
-                  </div>
-                </TableCell>
-              </TableRow>
-            ) : (
-              incidents.map((incident) => {
-                const isSelected = selectedIncidentIds.has(incident.id);
+			<div className="overflow-hidden rounded-xl border bg-card shadow-sm">
+				<div className="flex min-h-12 flex-col gap-3 border-b bg-muted/20 px-4 py-3 lg:flex-row lg:items-center lg:justify-between">
+					<div className="flex items-center gap-3 font-medium text-muted-foreground text-sm">
+						{currentPageIncidentIds.length > 0 ? (
+							<Checkbox
+								aria-label={
+									allCurrentPageSelected
+										? "Deselect all incidents on this page"
+										: "Select all incidents on this page"
+								}
+								checked={allCurrentPageSelected}
+								indeterminate={
+									someCurrentPageSelected && !allCurrentPageSelected
+								}
+								onCheckedChange={(checked) =>
+									toggleCurrentPageSelection(checked === true)
+								}
+							/>
+						) : (
+							<ChevronDown className="h-4 w-4" />
+						)}
+						<span>Incidents</span>
+						{total > 0 && (
+							<Badge className="rounded-full bg-muted px-2 py-0.5 text-muted-foreground text-xs">
+								{visibleStart}-{visibleEnd} of {total}
+							</Badge>
+						)}
+					</div>
+					{selectedCount > 0 && (
+						<div className="flex min-h-7 flex-wrap items-center gap-2 transition-opacity lg:justify-end">
+							<span className="mr-1 whitespace-nowrap font-medium text-foreground text-sm">
+								{formatIncidentCount(selectedCount)} selected
+							</span>
+							<span className="hidden text-muted-foreground text-xs sm:inline">
+								{selectedActionableCount > 0
+									? `${formatIncidentCount(selectedActionableCount)} can be updated`
+									: "Only delete is available for this selection"}
+							</span>
+							<Button
+								variant="outline"
+								size="xs"
+								onClick={() =>
+									runBulkAction("acknowledge", selectedUnacknowledgedOpenIds)
+								}
+								disabled={
+									bulkIncidentAction.isPending ||
+									selectedUnacknowledgedOpenIds.length === 0
+								}
+							>
+								<Check className="h-4 w-4" />
+								<span className="hidden sm:inline">
+									Acknowledge
+									{selectedUnacknowledgedOpenIds.length > 0
+										? ` (${selectedUnacknowledgedOpenIds.length})`
+										: ""}
+								</span>
+							</Button>
+							<Button
+								variant="outline"
+								size="xs"
+								onClick={() => runBulkAction("resolve", selectedOpenIds)}
+								disabled={
+									bulkIncidentAction.isPending || selectedOpenIds.length === 0
+								}
+							>
+								<CheckCircle2 className="h-4 w-4" />
+								<span className="hidden sm:inline">
+									Resolve
+									{selectedOpenIds.length > 0
+										? ` (${selectedOpenIds.length})`
+										: ""}
+								</span>
+							</Button>
+							<Button
+								variant="destructive-outline"
+								size="xs"
+								onClick={() => setBulkDeleteIds(selectedIds)}
+								disabled={bulkIncidentAction.isPending}
+							>
+								<Trash2 className="h-4 w-4" />
+								<span className="hidden sm:inline">Delete</span>
+							</Button>
+							<Button
+								variant="ghost"
+								size="icon-xs"
+								aria-label="Clear selection"
+								onClick={clearSelection}
+								disabled={bulkIncidentAction.isPending}
+							>
+								<X className="h-4 w-4" />
+							</Button>
+						</div>
+					)}
+				</div>
+				<Table>
+					<TableHeader>
+						<TableRow className="hover:bg-transparent">
+							<TableHead className="w-12 pr-0 pl-4">
+								<span className="sr-only">Select</span>
+							</TableHead>
+							<TableHead className="min-w-[280px] pl-2">Incident</TableHead>
+							<TableHead className="w-[150px]">Started</TableHead>
+							<TableHead className="w-[150px]">Status</TableHead>
+							<TableHead className="w-[52px] pr-4 text-right">
+								<span className="sr-only">Actions</span>
+							</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{isLoading ? (
+							<TableRow>
+								<TableCell colSpan={5} className="h-24 text-center">
+									<Loader2 className="mx-auto h-6 w-6 animate-spin text-muted-foreground" />
+								</TableCell>
+							</TableRow>
+						) : !incidents || incidents.length === 0 ? (
+							<TableRow>
+								<TableCell colSpan={5} className="h-24 text-center">
+									<div className="flex flex-col items-center justify-center gap-2 py-6">
+										<div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted/50">
+											<ShieldAlert className="h-6 w-6 text-muted-foreground" />
+										</div>
+										<p className="font-medium text-lg">No incidents found</p>
+										<p className="text-muted-foreground text-sm">
+											{search ||
+											statusFilter !== null ||
+											severityFilter ||
+											typeFilter ||
+											monitorFilter ||
+											statusPageFilter
+												? "Try adjusting your filters"
+												: "Get started by creating your first incident."}
+										</p>
+										{!search &&
+											statusFilter === null &&
+											!severityFilter &&
+											!typeFilter &&
+											!monitorFilter &&
+											!statusPageFilter && (
+												<div className="mt-2">
+													<Button
+														render={
+															<Link href="/incidents/new">Create incident</Link>
+														}
+													/>
+												</div>
+											)}
+									</div>
+								</TableCell>
+							</TableRow>
+						) : (
+							incidents.map((incident) => {
+								const isSelected = selectedIncidentIds.has(incident.id);
 
-                return (
-                  <TableRow
-                    key={incident.id}
-                    className="group h-[72px] cursor-pointer hover:bg-muted/40"
-                    data-state={isSelected ? "selected" : undefined}
-                    onClick={() => router.push(`/incidents/${incident.id}`)}
-                  >
-                    <TableCell
-                      className="w-12 pr-0 pl-4"
-                      onClick={(event) => event.stopPropagation()}
-                    >
-                      <Checkbox
-                        aria-label={`Select ${incident.title}`}
-                        checked={isSelected}
-                        onCheckedChange={(checked) =>
-                          toggleIncidentSelection(incident.id, checked === true)
-                        }
-                      />
-                    </TableCell>
-                    <TableCell className="min-w-[280px] pl-2">
-                      <Link
-                        href={`/incidents/${incident.id}`}
-                        className="flex items-center gap-4"
-                        onClick={(event) => event.stopPropagation()}
-                      >
-                        <div
-                          className={cn(
-                            "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border transition-colors",
-                            getStatusColor(incident.status),
-                          )}
-                        >
-                          {getStatusIcon(incident.status)}
-                        </div>
-                        <div className="grid gap-1">
-                          <span className="font-semibold leading-none transition-colors group-hover:text-primary">
-                            {incident.title}
-                          </span>
-                          <div className="flex flex-wrap items-center gap-2 text-muted-foreground text-sm">
-                            {incident.monitors.length > 0 && (
-                              <span className="flex items-center gap-1">
-                                {incident.monitors.length === 1
-                                  ? incident.monitors[0].monitor.name
-                                  : `${incident.monitors.length} monitors`}
-                              </span>
-                            )}
-                            {incident.type === "automatic" && (
-                              <Badge
-                                variant="outline"
-                                className="h-5 px-1.5 text-[10px]"
-                              >
-                                Auto
-                              </Badge>
-                            )}
-                            {incident.statusPages.length > 0 && (
-                              <Badge
-                                variant="secondary"
-                                className="h-5 px-1.5 text-[10px]"
-                              >
-                                Public
-                              </Badge>
-                            )}
-                            {incident.severity && (
-                              <Badge
-                                variant="outline"
-                                className={cn(
-                                  "h-5 border-none px-1.5 text-[10px] uppercase",
-                                  incident.severity === "minor" &&
-                                    "bg-blue-500/10 text-blue-500",
-                                  incident.severity === "major" &&
-                                    "bg-amber-500/10 text-amber-500",
-                                  incident.severity === "critical" &&
-                                    "bg-red-500/10 text-red-500",
-                                )}
-                              >
-                                {incident.severity}
-                              </Badge>
-                            )}
-                          </div>
-                        </div>
-                      </Link>
-                    </TableCell>
-                    <TableCell className="font-medium text-muted-foreground text-sm">
-                      {formatDistanceToNow(new Date(incident.startedAt), {
-                        addSuffix: true,
-                      })}
-                    </TableCell>
-                    <TableCell>
-                      <div className="flex items-center gap-2">
-                        <div
-                          className={cn(
-                            "h-2 w-2 rounded-full",
-                            incident.status !== "resolved"
-                              ? "animate-pulse bg-red-500"
-                              : "bg-muted-foreground/30",
-                          )}
-                        />
-                        <span
-                          className={cn(
-                            "font-medium text-sm capitalize",
-                            incident.status !== "resolved"
-                              ? "text-red-500"
-                              : "text-muted-foreground",
-                          )}
-                        >
-                          {incident.status}
-                        </span>
-                      </div>
-                    </TableCell>
-                    <TableCell className="w-[52px] pr-4">
-                      <DropdownMenu>
-                        <DropdownMenuTrigger
-                          render={
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              className="h-8 w-8 text-muted-foreground opacity-0 transition-opacity focus-visible:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100"
-                              onClick={(event) => event.stopPropagation()}
-                            />
-                          }
-                        >
-                          <MoreHorizontal className="h-4 w-4" />
-                          <span className="sr-only">Open menu</span>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end">
-                          <DropdownMenuItem
-                            render={<Link href={`/incidents/${incident.id}`} />}
-                          >
-                            View details
-                          </DropdownMenuItem>
-                          {!incident.endedAt && !incident.acknowledgedAt && (
-                            <DropdownMenuItem
-                              disabled={bulkIncidentAction.isPending}
-                              onSelect={() =>
-                                runBulkAction("acknowledge", [incident.id])
-                              }
-                            >
-                              <Check className="h-4 w-4" />
-                              Acknowledge
-                            </DropdownMenuItem>
-                          )}
-                          {!incident.endedAt && (
-                            <DropdownMenuItem
-                              disabled={bulkIncidentAction.isPending}
-                              onSelect={() =>
-                                runBulkAction("resolve", [incident.id])
-                              }
-                            >
-                              <CheckCircle2 className="h-4 w-4" />
-                              Resolve
-                            </DropdownMenuItem>
-                          )}
-                          <DropdownMenuSeparator />
-                          <DropdownMenuItem
-                            variant="destructive"
-                            onSelect={() =>
-                              setIncidentToDelete({
-                                id: incident.id,
-                                title: incident.title,
-                              })
-                            }
-                          >
-                            Delete
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    </TableCell>
-                  </TableRow>
-                );
-              })
-            )}
-          </TableBody>
-        </Table>
+								return (
+									<TableRow
+										key={incident.id}
+										className="group h-[72px] cursor-pointer hover:bg-muted/40"
+										data-state={isSelected ? "selected" : undefined}
+										onClick={() => router.push(`/incidents/${incident.id}`)}
+									>
+										<TableCell
+											className="w-12 pr-0 pl-4"
+											onClick={(event) => event.stopPropagation()}
+										>
+											<Checkbox
+												aria-label={`Select ${incident.title}`}
+												checked={isSelected}
+												onCheckedChange={(checked) =>
+													toggleIncidentSelection(incident.id, checked === true)
+												}
+											/>
+										</TableCell>
+										<TableCell className="min-w-[280px] pl-2">
+											<Link
+												href={`/incidents/${incident.id}`}
+												className="flex items-center gap-4"
+												onClick={(event) => event.stopPropagation()}
+											>
+												<div
+													className={cn(
+														"flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border transition-colors",
+														getStatusColor(incident.status),
+													)}
+												>
+													{getStatusIcon(incident.status)}
+												</div>
+												<div className="grid gap-1">
+													<span className="font-semibold leading-none transition-colors group-hover:text-primary">
+														{incident.title}
+													</span>
+													<div className="flex flex-wrap items-center gap-2 text-muted-foreground text-sm">
+														{incident.monitors.length > 0 && (
+															<span className="flex items-center gap-1">
+																{incident.monitors.length === 1
+																	? incident.monitors[0].monitor.name
+																	: `${incident.monitors.length} monitors`}
+															</span>
+														)}
+														{incident.type === "automatic" && (
+															<Badge
+																variant="outline"
+																className="h-5 px-1.5 text-[10px]"
+															>
+																Auto
+															</Badge>
+														)}
+														{incident.statusPages.length > 0 && (
+															<Badge
+																variant="secondary"
+																className="h-5 px-1.5 text-[10px]"
+															>
+																Public
+															</Badge>
+														)}
+														{incident.severity && (
+															<Badge
+																variant="outline"
+																className={cn(
+																	"h-5 border-none px-1.5 text-[10px] uppercase",
+																	incident.severity === "minor" &&
+																		"bg-blue-500/10 text-blue-500",
+																	incident.severity === "major" &&
+																		"bg-amber-500/10 text-amber-500",
+																	incident.severity === "critical" &&
+																		"bg-red-500/10 text-red-500",
+																)}
+															>
+																{incident.severity}
+															</Badge>
+														)}
+													</div>
+												</div>
+											</Link>
+										</TableCell>
+										<TableCell className="font-medium text-muted-foreground text-sm">
+											{formatDistanceToNow(new Date(incident.startedAt), {
+												addSuffix: true,
+											})}
+										</TableCell>
+										<TableCell>
+											<div className="flex items-center gap-2">
+												<div
+													className={cn(
+														"h-2 w-2 rounded-full",
+														incident.status !== "resolved"
+															? "animate-pulse bg-red-500"
+															: "bg-muted-foreground/30",
+													)}
+												/>
+												<span
+													className={cn(
+														"font-medium text-sm capitalize",
+														incident.status !== "resolved"
+															? "text-red-500"
+															: "text-muted-foreground",
+													)}
+												>
+													{incident.status}
+												</span>
+											</div>
+										</TableCell>
+										<TableCell className="w-[52px] pr-4">
+											<DropdownMenu>
+												<DropdownMenuTrigger
+													render={
+														<Button
+															variant="ghost"
+															size="icon"
+															className="h-8 w-8 text-muted-foreground opacity-0 transition-opacity focus-visible:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100"
+															onClick={(event) => event.stopPropagation()}
+														/>
+													}
+												>
+													<MoreHorizontal className="h-4 w-4" />
+													<span className="sr-only">Open menu</span>
+												</DropdownMenuTrigger>
+												<DropdownMenuContent align="end">
+													<DropdownMenuItem
+														render={<Link href={`/incidents/${incident.id}`} />}
+													>
+														View details
+													</DropdownMenuItem>
+													{!incident.endedAt && !incident.acknowledgedAt && (
+														<DropdownMenuItem
+															disabled={bulkIncidentAction.isPending}
+															onSelect={() =>
+																runBulkAction("acknowledge", [incident.id])
+															}
+														>
+															<Check className="h-4 w-4" />
+															Acknowledge
+														</DropdownMenuItem>
+													)}
+													{!incident.endedAt && (
+														<DropdownMenuItem
+															disabled={bulkIncidentAction.isPending}
+															onSelect={() =>
+																runBulkAction("resolve", [incident.id])
+															}
+														>
+															<CheckCircle2 className="h-4 w-4" />
+															Resolve
+														</DropdownMenuItem>
+													)}
+													<DropdownMenuSeparator />
+													<DropdownMenuItem
+														variant="destructive"
+														onSelect={() =>
+															setIncidentToDelete({
+																id: incident.id,
+																title: incident.title,
+															})
+														}
+													>
+														Delete
+													</DropdownMenuItem>
+												</DropdownMenuContent>
+											</DropdownMenu>
+										</TableCell>
+									</TableRow>
+								);
+							})
+						)}
+					</TableBody>
+				</Table>
 
-        {totalPages > 1 && (
-          <div className="flex items-center justify-end border-t bg-muted/20 px-4 py-3">
-            <Pagination className="mx-0 w-auto">
-              <PaginationContent>
-                <PaginationItem>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    disabled={page === 1}
-                    onClick={() => void setFilters({ page: page - 1 })}
-                  >
-                    <ChevronLeftIcon className="h-4 w-4" />
-                  </Button>
-                </PaginationItem>
-                {Array.from({ length: totalPages }, (_, i) => i + 1).map(
-                  (p) => {
-                    // Simple logic for small page counts. For larger, we need ellipsis logic.
-                    // For now, let's keep it simple or implement a window.
-                    if (
-                      totalPages > 7 &&
-                      (p < page - 2 || p > page + 2) &&
-                      p !== 1 &&
-                      p !== totalPages
-                    ) {
-                      if (p === page - 3 || p === page + 3) {
-                        return (
-                          <PaginationItem key={p}>
-                            <PaginationEllipsis />
-                          </PaginationItem>
-                        );
-                      }
-                      return null;
-                    }
+				{totalPages > 1 && (
+					<div className="flex items-center justify-end border-t bg-muted/20 px-4 py-3">
+						<Pagination className="mx-0 w-auto">
+							<PaginationContent>
+								<PaginationItem>
+									<Button
+										variant="ghost"
+										size="icon"
+										disabled={page === 1}
+										onClick={() => void setFilters({ page: page - 1 })}
+									>
+										<ChevronLeftIcon className="h-4 w-4" />
+									</Button>
+								</PaginationItem>
+								{Array.from({ length: totalPages }, (_, i) => i + 1).map(
+									(p) => {
+										// Simple logic for small page counts. For larger, we need ellipsis logic.
+										// For now, let's keep it simple or implement a window.
+										if (
+											totalPages > 7 &&
+											(p < page - 2 || p > page + 2) &&
+											p !== 1 &&
+											p !== totalPages
+										) {
+											if (p === page - 3 || p === page + 3) {
+												return (
+													<PaginationItem key={p}>
+														<PaginationEllipsis />
+													</PaginationItem>
+												);
+											}
+											return null;
+										}
 
-                    return (
-                      <PaginationItem key={p}>
-                        <Button
-                          variant={p === page ? "outline" : "ghost"}
-                          size="icon"
-                          onClick={() => void setFilters({ page: p })}
-                          className="h-8 w-8"
-                        >
-                          {p}
-                        </Button>
-                      </PaginationItem>
-                    );
-                  },
-                )}
-                <PaginationItem>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => void setFilters({ page: page + 1 })}
-                    disabled={page === totalPages}
-                  >
-                    <ChevronRightIcon className="h-4 w-4" />
-                  </Button>
-                </PaginationItem>
-              </PaginationContent>
-            </Pagination>
-          </div>
-        )}
-      </div>
+										return (
+											<PaginationItem key={p}>
+												<Button
+													variant={p === page ? "outline" : "ghost"}
+													size="icon"
+													onClick={() => void setFilters({ page: p })}
+													className="h-8 w-8"
+												>
+													{p}
+												</Button>
+											</PaginationItem>
+										);
+									},
+								)}
+								<PaginationItem>
+									<Button
+										variant="ghost"
+										size="icon"
+										onClick={() => void setFilters({ page: page + 1 })}
+										disabled={page === totalPages}
+									>
+										<ChevronRightIcon className="h-4 w-4" />
+									</Button>
+								</PaginationItem>
+							</PaginationContent>
+						</Pagination>
+					</div>
+				)}
+			</div>
 
-      <AlertDialog
-        open={bulkDeleteIds.length > 0}
-        onOpenChange={(open) => {
-          if (!open && !bulkIncidentAction.isPending) {
-            setBulkDeleteIds([]);
-          }
-        }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete selected incidents?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This action cannot be undone. This will permanently delete{" "}
-              {formatIncidentCount(bulkDeleteIds.length)} and all of their
-              activity history.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={bulkIncidentAction.isPending}>
-              Cancel
-            </AlertDialogCancel>
-            <Button
-              type="button"
-              variant="destructive"
-              onClick={() => runBulkAction("delete", bulkDeleteIds)}
-              disabled={bulkIncidentAction.isPending}
-            >
-              {bulkIncidentAction.isPending ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Deleting...
-                </>
-              ) : (
-                "Delete"
-              )}
-            </Button>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+			<AlertDialog
+				open={bulkDeleteIds.length > 0}
+				onOpenChange={(open) => {
+					if (!open && !bulkIncidentAction.isPending) {
+						setBulkDeleteIds([]);
+					}
+				}}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete selected incidents?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This action cannot be undone. This will permanently delete{" "}
+							{formatIncidentCount(bulkDeleteIds.length)} and all of their
+							activity history.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel disabled={bulkIncidentAction.isPending}>
+							Cancel
+						</AlertDialogCancel>
+						<Button
+							type="button"
+							variant="destructive"
+							onClick={() => runBulkAction("delete", bulkDeleteIds)}
+							disabled={bulkIncidentAction.isPending}
+						>
+							{bulkIncidentAction.isPending ? (
+								<>
+									<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+									Deleting...
+								</>
+							) : (
+								"Delete"
+							)}
+						</Button>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
 
-      <AlertDialog
-        open={!!incidentToDelete}
-        onOpenChange={(open) => !open && setIncidentToDelete(null)}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This action cannot be undone. This will permanently delete the
-              incident &quot;
-              {incidentToDelete?.title}&quot; and all of its activity history.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
-            <Button
-              type="button"
-              variant="destructive"
-              onClick={() =>
-                incidentToDelete && deleteIncident(incidentToDelete.id)
-              }
-              disabled={isDeleting}
-            >
-              {isDeleting ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Deleting...
-                </>
-              ) : (
-                "Delete"
-              )}
-            </Button>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </div>
-  );
+			<AlertDialog
+				open={!!incidentToDelete}
+				onOpenChange={(open) => !open && setIncidentToDelete(null)}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This action cannot be undone. This will permanently delete the
+							incident &quot;
+							{incidentToDelete?.title}&quot; and all of its activity history.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+						<Button
+							type="button"
+							variant="destructive"
+							onClick={() =>
+								incidentToDelete && deleteIncident(incidentToDelete.id)
+							}
+							disabled={isDeleting}
+						>
+							{isDeleting ? (
+								<>
+									<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+									Deleting...
+								</>
+							) : (
+								"Delete"
+							)}
+						</Button>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</div>
+	);
 }

--- a/apps/dash/src/components/integrations/table.tsx
+++ b/apps/dash/src/components/integrations/table.tsx
@@ -89,7 +89,7 @@ const NOTIFICATION_STATUS_FILTERS = ["active", "inactive"] as const;
 const NOTIFICATION_DIRECTION_FILTERS = ["export", "import"] as const;
 const NOTIFICATION_DEFAULT_FILTERS = ["default", "custom"] as const;
 
-type ConfiguredNotification = {
+interface ConfiguredNotification {
 	id: string;
 	name: string;
 	type: string;
@@ -97,7 +97,7 @@ type ConfiguredNotification = {
 	active: boolean;
 	isDefault: boolean;
 	assignedMonitorCount: number;
-};
+}
 
 const frontendRegistry = {
 	webhook: {

--- a/apps/dash/src/components/monitors/create-form.tsx
+++ b/apps/dash/src/components/monitors/create-form.tsx
@@ -176,19 +176,19 @@ const monitorConfigSchema = z.discriminatedUnion("type", [
 const formSchema = z.intersection(baseSchema, monitorConfigSchema);
 
 type FormValues = z.infer<typeof formSchema>;
-type ActiveWorkerOption = {
+interface ActiveWorkerOption {
 	id: string;
 	name: string;
 	location: string;
-};
+}
 
-type ConfiguredNotification = {
+interface ConfiguredNotification {
 	id: string;
 	name: string;
 	type: string;
 	active: boolean;
 	isDefault: boolean;
-};
+}
 
 const heartbeatPeriodOptions = [
 	{ label: "1 minute", value: "60" },
@@ -214,7 +214,7 @@ const recoveryPeriodOptions = [
 ] as const;
 
 // Registry for UI components and metadata
-type MonitorTypeDefinition = {
+interface MonitorTypeDefinition {
 	id: FormValues["type"];
 	label: string;
 	description: string;
@@ -222,7 +222,7 @@ type MonitorTypeDefinition = {
 	group: "Network & web" | "Infrastructure";
 	// Component to render specific fields
 	Fields: React.ComponentType<{ form: UseFormReturn<FormValues> }>;
-};
+}
 
 // Reusable field components
 const UrlField = ({ form }: { form: UseFormReturn<FormValues> }) => (

--- a/apps/dash/src/components/settings/api-key-settings.tsx
+++ b/apps/dash/src/components/settings/api-key-settings.tsx
@@ -43,7 +43,7 @@ import {
 } from "@/components/ui/table";
 import { authClient } from "@/lib/auth-client";
 
-type ApiKeyRecord = {
+interface ApiKeyRecord {
 	id: string;
 	name: string | null;
 	start: string | null;
@@ -53,7 +53,7 @@ type ApiKeyRecord = {
 	lastRequest: Date | string | null;
 	expiresAt: Date | string | null;
 	createdAt: Date | string;
-};
+}
 
 type CreatedApiKey = ApiKeyRecord & {
 	key: string;

--- a/apps/dash/src/components/settings/group-settings.tsx
+++ b/apps/dash/src/components/settings/group-settings.tsx
@@ -1,9 +1,9 @@
 import { GroupsManager } from "@/components/monitors/groups-manager";
 import { Card, CardContent } from "@/components/ui/card";
 
-type GroupSettingsProps = {
+interface GroupSettingsProps {
 	readOnly?: boolean;
-};
+}
 
 /**
  * Render a responsive settings view for creating and organizing monitor groups.

--- a/apps/dash/src/components/settings/members-table.tsx
+++ b/apps/dash/src/components/settings/members-table.tsx
@@ -54,9 +54,9 @@ const memberRoleOptions = [
 	{ label: "Member", value: "member" },
 ] as const;
 
-type MembersTableProps = {
+interface MembersTableProps {
 	canManageMembers: boolean;
-};
+}
 
 export function MembersTable({ canManageMembers }: MembersTableProps) {
 	const {

--- a/apps/dash/src/components/settings/organization-settings-client.tsx
+++ b/apps/dash/src/components/settings/organization-settings-client.tsx
@@ -50,9 +50,9 @@ const formSchema = z.object({
 		.or(z.literal("")),
 });
 
-type OrganizationSettingsClientProps = {
+interface OrganizationSettingsClientProps {
 	organizationId: string;
-};
+}
 
 function LoadingState({ label = "Loading organization settings..." }) {
 	return (

--- a/apps/dash/src/components/settings/tag-settings.tsx
+++ b/apps/dash/src/components/settings/tag-settings.tsx
@@ -1,9 +1,9 @@
 import { TagsManager } from "@/components/monitors/tags-manager";
 import { Card, CardContent } from "@/components/ui/card";
 
-type TagSettingsProps = {
+interface TagSettingsProps {
 	readOnly?: boolean;
-};
+}
 
 /**
  * Render a responsive settings section for creating and managing tags.

--- a/apps/dash/src/components/settings/team-settings.tsx
+++ b/apps/dash/src/components/settings/team-settings.tsx
@@ -10,9 +10,9 @@ import {
 import { InviteMemberDialog } from "./invite-member-dialog";
 import { MembersTable } from "./members-table";
 
-type TeamSettingsProps = {
+interface TeamSettingsProps {
 	canManageMembers: boolean;
-};
+}
 
 export function TeamSettings({ canManageMembers }: TeamSettingsProps) {
 	return (

--- a/apps/dash/src/components/status-pages/table.tsx
+++ b/apps/dash/src/components/status-pages/table.tsx
@@ -42,7 +42,7 @@ import { DataPagination } from "../ui/data-pagination";
 import { DropdownMenuLabel, MenuGroup } from "../ui/menu";
 import { CreateStatusPageForm } from "./create-form";
 
-type StatusPageListItem = {
+interface StatusPageListItem {
 	id: string;
 	name: string;
 	slug: string;
@@ -51,7 +51,7 @@ type StatusPageListItem = {
 	subscribers: number;
 	public: boolean;
 	description: string | null;
-};
+}
 
 export function StatusPagesTable() {
 	const router = useRouter();

--- a/apps/dash/src/components/ui/carousel.tsx
+++ b/apps/dash/src/components/ui/carousel.tsx
@@ -11,12 +11,12 @@ type UseCarouselParameters = Parameters<typeof useEmblaCarousel>;
 type CarouselOptions = UseCarouselParameters[0];
 type CarouselPlugin = UseCarouselParameters[1];
 
-type CarouselProps = {
+interface CarouselProps {
 	opts?: CarouselOptions;
 	plugins?: CarouselPlugin;
 	orientation?: "horizontal" | "vertical";
 	setApi?: (api: CarouselApi) => void;
-};
+}
 
 type CarouselContextProps = {
 	carouselRef: ReturnType<typeof useEmblaCarousel>[0];

--- a/apps/dash/src/components/ui/chart.tsx
+++ b/apps/dash/src/components/ui/chart.tsx
@@ -18,9 +18,9 @@ export type ChartConfig = {
 	);
 };
 
-type ChartContextProps = {
+interface ChartContextProps {
 	config: ChartConfig;
-};
+}
 
 const ChartContext = React.createContext<ChartContextProps | null>(null);
 

--- a/apps/dash/src/components/ui/combobox.tsx
+++ b/apps/dash/src/components/ui/combobox.tsx
@@ -29,10 +29,10 @@ type ComboboxRootProps<
 	searchParamKey?: string;
 };
 
-type FilterableElementProps = {
+interface FilterableElementProps {
 	children?: React.ReactNode;
 	value?: unknown;
-};
+}
 
 function getSearchParamKey(value: string | undefined): string {
 	const rawKey = value || "q";

--- a/apps/dash/src/components/ui/form.tsx
+++ b/apps/dash/src/components/ui/form.tsx
@@ -15,12 +15,12 @@ import { cn } from "@/lib/utils";
 
 const Form = FormProvider;
 
-type FormFieldContextValue<
+interface FormFieldContextValue<
 	TFieldValues extends FieldValues = FieldValues,
 	TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
-> = {
+> {
 	name: TName;
-};
+}
 
 const FormFieldContext = React.createContext<FormFieldContextValue>(
 	{} as FormFieldContextValue,
@@ -37,9 +37,9 @@ export function FormField<
 	);
 }
 
-type FormItemContextValue = {
+interface FormItemContextValue {
 	id: string;
-};
+}
 
 const FormItemContext = React.createContext<FormItemContextValue>(
 	{} as FormItemContextValue,

--- a/apps/dash/src/components/ui/input.tsx
+++ b/apps/dash/src/components/ui/input.tsx
@@ -4,11 +4,11 @@ import { Input as InputPrimitive } from "@base-ui/react/input";
 import type * as React from "react";
 import { cn } from "@/lib/utils";
 
-type InputOwnProps = {
+interface InputOwnProps {
 	className?: string;
 	size?: "sm" | "default" | "lg" | number;
 	unstyled?: boolean;
-};
+}
 
 type NativeInputProps = Omit<
 	React.ComponentPropsWithRef<"input">,

--- a/apps/dash/src/components/ui/map.tsx
+++ b/apps/dash/src/components/ui/map.tsx
@@ -82,10 +82,10 @@ function useResolvedTheme(themeProp?: "light" | "dark"): Theme {
 	return themeProp ?? detectedTheme;
 }
 
-type MapContextValue = {
+interface MapContextValue {
 	map: MapLibreGL.Map | null;
 	isLoaded: boolean;
-};
+}
 
 const MapContext = createContext<MapContextValue | null>(null);
 
@@ -98,7 +98,7 @@ function useMap() {
 }
 
 /** Map viewport state */
-type MapViewport = {
+interface MapViewport {
 	/** Center coordinates [longitude, latitude] */
 	center: [number, number];
 	/** Zoom level */
@@ -107,7 +107,7 @@ type MapViewport = {
 	bearing: number;
 	/** Pitch (tilt) in degrees */
 	pitch: number;
-};
+}
 
 type MapStyleOption = string | MapLibreGL.StyleSpecification;
 
@@ -335,10 +335,10 @@ const MapRoot = forwardRef<MapRef, MapProps>(function MapRoot(
 	);
 });
 
-type MarkerContextValue = {
+interface MarkerContextValue {
 	marker: MapLibreGL.Marker;
 	map: MapLibreGL.Map | null;
-};
+}
 
 const MarkerContext = createContext<MarkerContextValue | null>(null);
 
@@ -494,12 +494,12 @@ function MapMarker({
 	);
 }
 
-type MarkerContentProps = {
+interface MarkerContentProps {
 	/** Custom marker content. Defaults to a blue dot if not provided */
 	children?: ReactNode;
 	/** Additional CSS classes for the marker container */
 	className?: string;
-};
+}
 
 function MarkerContent({ children, className }: MarkerContentProps) {
 	const { marker } = useMarkerContext();
@@ -671,14 +671,14 @@ function MarkerTooltip({
 	);
 }
 
-type MarkerLabelProps = {
+interface MarkerLabelProps {
 	/** Label text content */
 	children: ReactNode;
 	/** Additional CSS classes for the label */
 	className?: string;
 	/** Position of the label relative to the marker (default: "top") */
 	position?: "top" | "bottom";
-};
+}
 
 function MarkerLabel({
 	children,
@@ -704,7 +704,7 @@ function MarkerLabel({
 	);
 }
 
-type MapControlsProps = {
+interface MapControlsProps {
 	/** Position of the controls on the map (default: "bottom-right") */
 	position?: "top-left" | "top-right" | "bottom-left" | "bottom-right";
 	/** Show zoom in/out buttons (default: true) */
@@ -719,7 +719,7 @@ type MapControlsProps = {
 	className?: string;
 	/** Callback with user coordinates when located */
 	onLocate?: (coords: { longitude: number; latitude: number }) => void;
-};
+}
 
 const positionClasses = {
 	"top-left": "top-2 left-2",
@@ -1024,7 +1024,7 @@ function MapPopup({
 	);
 }
 
-type MapRouteProps = {
+interface MapRouteProps {
 	/** Optional unique identifier for the route layer */
 	id?: string;
 	/** Array of [longitude, latitude] coordinate pairs defining the route */
@@ -1045,7 +1045,7 @@ type MapRouteProps = {
 	onMouseLeave?: () => void;
 	/** Whether the route is interactive - shows pointer cursor on hover (default: true) */
 	interactive?: boolean;
-};
+}
 
 function MapRoute({
 	id: propId,
@@ -1165,9 +1165,9 @@ function MapRoute({
 	return null;
 }
 
-type MapClusterLayerProps<
+interface MapClusterLayerProps<
 	P extends GeoJSON.GeoJsonProperties = GeoJSON.GeoJsonProperties,
-> = {
+> {
 	/** GeoJSON FeatureCollection data or URL to fetch GeoJSON from */
 	data: string | GeoJSON.FeatureCollection<GeoJSON.Point, P>;
 	/** Maximum zoom level to cluster points on (default: 14) */
@@ -1191,7 +1191,7 @@ type MapClusterLayerProps<
 		coordinates: [number, number],
 		pointCount: number,
 	) => void;
-};
+}
 
 function MapClusterLayer<
 	P extends GeoJSON.GeoJsonProperties = GeoJSON.GeoJsonProperties,

--- a/apps/dash/src/components/ui/sidebar.tsx
+++ b/apps/dash/src/components/ui/sidebar.tsx
@@ -50,7 +50,7 @@ const sidebarMenuButtonVariants = cva(
 	},
 );
 
-export type SidebarContextProps = {
+export interface SidebarContextProps {
 	state: "expanded" | "collapsed";
 	open: boolean;
 	setOpen: (open: boolean) => void;
@@ -58,7 +58,7 @@ export type SidebarContextProps = {
 	setOpenMobile: (open: boolean) => void;
 	isMobile: boolean;
 	toggleSidebar: () => void;
-};
+}
 
 export const SidebarContext: React.Context<SidebarContextProps | null> =
 	React.createContext<SidebarContextProps | null>(null);

--- a/apps/dash/src/hooks/use-media-query.ts
+++ b/apps/dash/src/hooks/use-media-query.ts
@@ -61,12 +61,12 @@ function getServerSnapshot(): boolean {
 	return false;
 }
 
-export type MediaQueryInput = {
+export interface MediaQueryInput {
 	min?: Breakpoint | number;
 	max?: Breakpoint | number;
 	/** Touch-like input (finger). Use "fine" for mouse/trackpad. */
 	pointer?: "coarse" | "fine";
-};
+}
 
 export function useMediaQuery(
 	query: BreakpointQuery | MediaQueryInput | (string & {}),

--- a/apps/dash/src/lib/auth-client.ts
+++ b/apps/dash/src/lib/auth-client.ts
@@ -31,7 +31,7 @@ type AuthClientResponse<TData> = Promise<
 	  }
 >;
 
-type ApiKeyClientMethods = {
+interface ApiKeyClientMethods {
 	apiKey: {
 		create: (
 			data: Record<string, unknown>,
@@ -50,7 +50,7 @@ type ApiKeyClientMethods = {
 			options?: unknown,
 		) => AuthClientResponse<unknown>;
 	};
-};
+}
 
 const baseAuthClient = createAuthClient({
 	plugins: [...authClientPlugins],

--- a/apps/status-page/src/components/subscribe-form.tsx
+++ b/apps/status-page/src/components/subscribe-form.tsx
@@ -11,10 +11,10 @@ interface SubscribeFormProps {
 	mode?: "card" | "compact";
 }
 
-type SubscribeState = {
+interface SubscribeState {
 	error: string;
 	success: string;
-};
+}
 
 const variantStyles = {
 	default: {

--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -6,9 +6,9 @@ import {
 } from "@uptimekit/auth";
 import type { NextRequest } from "next/server";
 
-type ContextHeaders = {
+export interface ContextHeaders {
 	get(name: string): string | null;
-};
+}
 
 type ApiKeyContext =
 	| {
@@ -22,17 +22,17 @@ type ApiKeyContext =
 			organizationId: null;
 	  };
 
-export type Context = {
+export interface Context {
 	apiKey: ApiKeyContext | null;
 	authType: "anonymous" | "apiKey" | "session";
 	headers: ContextHeaders;
 	session: UptimeKitAuthSession | null;
-};
+}
 
-type VerifiedApiKey = {
+interface VerifiedApiKey {
 	id: string;
 	referenceId: string;
-};
+}
 
 function createApiKeySession(
 	apiKey: VerifiedApiKey,

--- a/packages/api/src/lib/admin-users.ts
+++ b/packages/api/src/lib/admin-users.ts
@@ -1,12 +1,12 @@
 export type AdminUserAction = "ban" | "delete" | "demote";
 
-type AdminUserActionCheck = {
+interface AdminUserActionCheck {
 	action: AdminUserAction;
 	adminCount: number;
 	currentUserId: string;
 	targetRole: string | null | undefined;
 	targetUserId: string;
-};
+}
 
 export function isInstanceAdminRole(role: string | null | undefined) {
 	return (

--- a/packages/api/src/lib/events.ts
+++ b/packages/api/src/lib/events.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "node:events";
 
-type AppEvents = {
+interface AppEvents {
 	"incident.created": {
 		incidentId: string;
 		organizationId: string;
@@ -50,7 +50,7 @@ type AppEvents = {
 		error?: string;
 		threshold: number;
 	};
-};
+}
 
 class TypedEventEmitter extends EventEmitter {
 	emit<K extends keyof AppEvents>(event: K, payload: AppEvents[K]): boolean {

--- a/packages/api/src/lib/organization-limits.ts
+++ b/packages/api/src/lib/organization-limits.ts
@@ -21,13 +21,13 @@ export type QuotaPauseReason =
 type TransactionLike = Parameters<Parameters<typeof db.transaction>[0]>[0];
 type QueryableDatabase = typeof db | TransactionLike;
 
-export type OrganizationQuotaState = {
+export interface OrganizationQuotaState {
 	organizationId: string;
 	activeMonitorLimit: number | null;
 	regionsPerMonitorLimit: number | null;
 	activeMonitorCount: number;
 	totalMonitorCount: number;
-};
+}
 
 export async function getOrganizationQuotaState(
 	organizationId: string,

--- a/packages/api/src/pkg/subscribers/email.ts
+++ b/packages/api/src/pkg/subscribers/email.ts
@@ -1,11 +1,11 @@
 import nodemailer from "nodemailer";
 
-type SubscriberEmailInput = {
+interface SubscriberEmailInput {
 	to: string;
 	subject: string;
 	text: string;
 	html?: string;
-};
+}
 
 function getEmailProvider() {
 	return (process.env.EMAIL_PROVIDER || "").trim().toLowerCase();

--- a/packages/api/src/pkg/subscribers/service.ts
+++ b/packages/api/src/pkg/subscribers/service.ts
@@ -15,21 +15,21 @@ const logger = createLogger("SUBSCRIBERS");
 
 type SubscriberEventName = "incident.acknowledged" | "incident.resolved";
 
-type SubscriberEventPayload = {
+interface SubscriberEventPayload {
 	incidentId: string;
 	organizationId: string;
 	title: string;
 	description?: string | null;
 	severity: "minor" | "major" | "critical";
-};
+}
 
-type SubscriberStatusPage = {
+interface SubscriberStatusPage {
 	id: string;
 	name: string;
 	slug: string;
 	domain: string | null;
 	design: unknown;
-};
+}
 
 const eventLabels: Record<SubscriberEventName, string> = {
 	"incident.acknowledged": "Incident acknowledged",

--- a/packages/api/src/pkg/subscribers/templates.ts
+++ b/packages/api/src/pkg/subscribers/templates.ts
@@ -1,11 +1,11 @@
-type SubscriberEmailTemplateInput = {
+interface SubscriberEmailTemplateInput {
 	eventLabel: string;
 	statusPageName: string;
 	incidentTitle: string;
 	severity: string;
 	description: string;
 	incidentUrl: string;
-};
+}
 
 function escapeHtml(value: string) {
 	return value

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -32,7 +32,7 @@ export function getApiKeyFromHeaders(headers: Headers | null | undefined) {
 	return token.trim() || null;
 }
 
-export type UptimeKitAuthSession = {
+export interface UptimeKitAuthSession {
 	session: {
 		id: string;
 		token: string;
@@ -59,7 +59,7 @@ export type UptimeKitAuthSession = {
 		banExpires?: Date | null;
 		twoFactorEnabled?: boolean | null;
 	};
-};
+}
 
 function createSlugFromEmail(email: string): string {
 	const prefix = email.split("@")[0] || "user";

--- a/packages/db/src/timeseries/clickhouse.ts
+++ b/packages/db/src/timeseries/clickhouse.ts
@@ -16,13 +16,13 @@ import type {
 	WorkerStatus,
 } from "./types";
 
-type BootstrapQuery = {
+interface BootstrapQuery {
 	query: string;
 	optionalTable?: {
 		database: string;
 		table: string;
 	};
-};
+}
 
 const BOOTSTRAP_QUERIES: BootstrapQuery[] = [
 	{ query: "CREATE DATABASE IF NOT EXISTS uptimekit" },


### PR DESCRIPTION
Convert `type X = { ... }` declarations to `interface X { ... }` where the right-hand side is a plain object literal. Leave `type` for unions, intersections, mapped/conditional types, function types, simple aliases, and utility-type results (z.infer, Pick, Omit, etc.).

Also exports ContextHeaders from packages/api/src/context.ts so the public Context interface can name it (TS4023).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization by standardizing TypeScript type declarations across the codebase. No changes to application functionality or user-facing features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uptimekit/uptimekit/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->