### PR TITLE
fix(telegram): use payload.description in test message body

### DIFF
--- a/packages/api/src/pkg/integrations/definitions/telegram.ts
+++ b/packages/api/src/pkg/integrations/definitions/telegram.ts
@@ -23,7 +23,7 @@ export const telegramIntegration: IntegrationDefinition<
 					"<b>Status:</b> Your Telegram integration is working correctly!",
 					"",
 					"<b>Message:</b>",
-					`<pre>${payload.message}</pre>`,
+					`<pre>${payload.description || "No details provided"}</pre>`,
 					"",
 					`<b>Timestamp:</b> ${new Date().toLocaleString()}`,
 				].join("\n");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Telegram test event notifications with improved message formatting that prioritizes description content for better event visibility. When description details are unavailable, a helpful default message is displayed to ensure meaningful event information in notifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uptimekit/uptimekit/pull/119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->