### PR TITLE
fix: latency chart time offset with multiple workers

### DIFF
--- a/packages/api/src/routers/monitors.ts
+++ b/packages/api/src/routers/monitors.ts
@@ -1177,11 +1177,16 @@ export const monitorsRouter = {
 					? input.workerIds
 					: undefined;
 
+			// Scale the cap by worker count; a single shared cap would shrink the
+			// visible time window as more workers compete for the same row budget.
+			const workerCount = Math.max(filterLocations?.length ?? 1, 1);
+			const limit = input.allChecks ? null : 2000 * workerCount;
+
 			const events = await timeseries.getResponseTimes({
 				monitorId: input.monitorId,
 				since: startDate,
 				locations: filterLocations,
-				limit: input.allChecks ? null : 2000,
+				limit,
 			});
 
 			return events.map((e) => ({

--- a/packages/db/src/timeseries/clickhouse.ts
+++ b/packages/db/src/timeseries/clickhouse.ts
@@ -425,22 +425,26 @@ export class ClickHouseDriver implements TimeSeriesDriver {
 				WHERE monitorId = {monitorId:String}
 					AND timestamp >= toDateTime64({startDate:UInt64} / 1000, 3)
 					${locationFilter}
-				ORDER BY timestamp ASC
+				ORDER BY timestamp DESC
 				${limitClause}
 			`,
 			params,
 		);
 
-		return rows.map((r) => ({
-			timestamp: parseTimestamp(r.timestamp),
-			location: r.location ?? null,
-			latency: Number(r.latency) || 0,
-			dnsLookup: r.dnsLookup != null ? Number(r.dnsLookup) : null,
-			tcpConnect: r.tcpConnect != null ? Number(r.tcpConnect) : null,
-			tlsHandshake: r.tlsHandshake != null ? Number(r.tlsHandshake) : null,
-			ttfb: r.ttfb != null ? Number(r.ttfb) : null,
-			transfer: r.transfer != null ? Number(r.transfer) : null,
-		}));
+		// Fetched newest-first so the LIMIT keeps the most recent rows, not the
+		// oldest; reverse to return ascending order.
+		return rows
+			.map((r) => ({
+				timestamp: parseTimestamp(r.timestamp),
+				location: r.location ?? null,
+				latency: Number(r.latency) || 0,
+				dnsLookup: r.dnsLookup != null ? Number(r.dnsLookup) : null,
+				tcpConnect: r.tcpConnect != null ? Number(r.tcpConnect) : null,
+				tlsHandshake: r.tlsHandshake != null ? Number(r.tlsHandshake) : null,
+				ttfb: r.ttfb != null ? Number(r.ttfb) : null,
+				transfer: r.transfer != null ? Number(r.transfer) : null,
+			}))
+			.reverse();
 	}
 
 	async getRecentLatenciesByMonitor(

--- a/packages/db/src/timeseries/driver-suite.ts
+++ b/packages/db/src/timeseries/driver-suite.ts
@@ -476,6 +476,44 @@ export function defineDriverTests(
 				expect(capped).toHaveLength(1);
 				expect(uncapped).toHaveLength(3);
 			});
+
+			it("keeps the most recent events when the limit caps the result", async () => {
+				const driver = getDriver();
+				const monitorId = uid("response-recent");
+				const now = new Date();
+
+				await driver.insertMonitorEvents([
+					{
+						id: crypto.randomUUID(),
+						monitorId,
+						status: "up",
+						latency: 100,
+						timestamp: new Date(now.getTime() - 120_000),
+					},
+					{
+						id: crypto.randomUUID(),
+						monitorId,
+						status: "up",
+						latency: 150,
+						timestamp: new Date(now.getTime() - 60_000),
+					},
+					{
+						id: crypto.randomUUID(),
+						monitorId,
+						status: "up",
+						latency: 200,
+						timestamp: now,
+					},
+				]);
+
+				const capped = await driver.getResponseTimes({
+					monitorId,
+					since: new Date(now.getTime() - 180_000),
+					limit: 2,
+				});
+
+				expect(capped.map((point) => point.latency)).toEqual([150, 200]);
+			});
 		});
 
 		describe("worker status snapshots", () => {

--- a/packages/db/src/timeseries/driver-suite.ts
+++ b/packages/db/src/timeseries/driver-suite.ts
@@ -514,6 +514,86 @@ export function defineDriverTests(
 
 				expect(capped.map((point) => point.latency)).toEqual([150, 200]);
 			});
+
+			it("keeps the most recent events per location when filtered and capped", async () => {
+				const driver = getDriver();
+				const monitorId = uid("response-recent-locations");
+				const now = new Date();
+
+				await driver.insertMonitorEvents([
+					{
+						id: crypto.randomUUID(),
+						monitorId,
+						status: "up",
+						latency: 10,
+						timestamp: new Date(now.getTime() - 250_000),
+						location: "worker-a",
+					},
+					{
+						id: crypto.randomUUID(),
+						monitorId,
+						status: "up",
+						latency: 20,
+						timestamp: new Date(now.getTime() - 200_000),
+						location: "worker-b",
+					},
+					{
+						id: crypto.randomUUID(),
+						monitorId,
+						status: "up",
+						latency: 30,
+						timestamp: new Date(now.getTime() - 150_000),
+						location: "worker-a",
+					},
+					{
+						id: crypto.randomUUID(),
+						monitorId,
+						status: "up",
+						latency: 40,
+						timestamp: new Date(now.getTime() - 100_000),
+						location: "worker-b",
+					},
+					{
+						id: crypto.randomUUID(),
+						monitorId,
+						status: "up",
+						latency: 50,
+						timestamp: new Date(now.getTime() - 50_000),
+						location: "worker-a",
+					},
+					{
+						id: crypto.randomUUID(),
+						monitorId,
+						status: "up",
+						latency: 60,
+						timestamp: new Date(now.getTime() - 30_000),
+						location: "worker-b",
+					},
+					{
+						id: crypto.randomUUID(),
+						monitorId,
+						status: "up",
+						latency: 999,
+						timestamp: now,
+						location: "worker-c",
+					},
+				]);
+
+				const capped = await driver.getResponseTimes({
+					monitorId,
+					since: new Date(now.getTime() - 300_000),
+					locations: ["worker-a", "worker-b"],
+					limit: 4,
+				});
+
+				expect(capped.map((point) => point.latency)).toEqual([30, 40, 50, 60]);
+				expect(capped.map((point) => point.location)).toEqual([
+					"worker-a",
+					"worker-b",
+					"worker-a",
+					"worker-b",
+				]);
+			});
 		});
 
 		describe("worker status snapshots", () => {

--- a/packages/db/src/timeseries/timescale.ts
+++ b/packages/db/src/timeseries/timescale.ts
@@ -348,7 +348,7 @@ export class TimescaleDriver implements TimeSeriesDriver {
 					WHERE monitor_id = ${query.monitorId}
 						AND timestamp >= ${query.since}
 						AND location = ANY(${query.locations as string[]})
-					ORDER BY timestamp ASC
+					ORDER BY timestamp DESC
 					${limitClause}
 				`
 			: await sql<
@@ -368,20 +368,24 @@ export class TimescaleDriver implements TimeSeriesDriver {
 					FROM monitor_events
 					WHERE monitor_id = ${query.monitorId}
 						AND timestamp >= ${query.since}
-					ORDER BY timestamp ASC
+					ORDER BY timestamp DESC
 					${limitClause}
 				`;
 
-		return rows.map((r) => ({
-			timestamp: r.timestamp,
-			location: r.location ?? null,
-			latency: Number(r.latency) || 0,
-			dnsLookup: r.dns_lookup != null ? Number(r.dns_lookup) : null,
-			tcpConnect: r.tcp_connect != null ? Number(r.tcp_connect) : null,
-			tlsHandshake: r.tls_handshake != null ? Number(r.tls_handshake) : null,
-			ttfb: r.ttfb != null ? Number(r.ttfb) : null,
-			transfer: r.transfer != null ? Number(r.transfer) : null,
-		}));
+		// Fetched newest-first so the LIMIT keeps the most recent rows, not the
+		// oldest; reverse to return ascending order.
+		return rows
+			.map((r) => ({
+				timestamp: r.timestamp,
+				location: r.location ?? null,
+				latency: Number(r.latency) || 0,
+				dnsLookup: r.dns_lookup != null ? Number(r.dns_lookup) : null,
+				tcpConnect: r.tcp_connect != null ? Number(r.tcp_connect) : null,
+				tlsHandshake: r.tls_handshake != null ? Number(r.tls_handshake) : null,
+				ttfb: r.ttfb != null ? Number(r.ttfb) : null,
+				transfer: r.transfer != null ? Number(r.transfer) : null,
+			}))
+			.reverse();
 	}
 
 	async getRecentLatenciesByMonitor(


### PR DESCRIPTION
getResponseTimes ordered by timestamp ASC before applying the row cap, returning the oldest rows in the range. With a single worker the check count stayed under the cap, but selecting multiple workers multiplied the rows so the cap dropped the most recent data, making the chart appear shifted hours into the past.

Fetch newest-first so the cap keeps the most recent rows (reversed back to ascending for the caller), and scale the cap by the number of selected workers so the visible window no longer shrinks as workers are added.