### PR TITLE
fix: run husky pre-commit hooks with pnpm and direct Biome spawn

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-bunx commitlint --edit $1
+pnpm exec commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged
+pnpm exec lint-staged

--- a/scripts/biome-safe.js
+++ b/scripts/biome-safe.js
@@ -20,6 +20,7 @@ const command = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
 
 const child = spawn(command, ["exec", ...args], {
 	stdio: "inherit",
+	shell: process.platform === "win32",
 });
 
 child.on("error", (err) => {

--- a/scripts/biome-safe.js
+++ b/scripts/biome-safe.js
@@ -1,5 +1,8 @@
 import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
 import process from "node:process";
+import { fileURLToPath } from "node:url";
 
 const files = process.argv.slice(2);
 
@@ -7,8 +10,11 @@ if (files.length === 0) {
 	process.exit(0);
 }
 
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const require = createRequire(join(repoRoot, "package.json"));
+const biomeBin = require.resolve("@biomejs/biome/bin/biome");
+
 const args = [
-	"biome",
 	"check",
 	"--write",
 	"--no-errors-on-unmatched",
@@ -16,15 +22,12 @@ const args = [
 	...files,
 ];
 
-const command = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
-
-const child = spawn(command, ["exec", ...args], {
+const child = spawn(process.execPath, [biomeBin, ...args], {
 	stdio: "inherit",
-	shell: process.platform === "win32",
 });
 
 child.on("error", (err) => {
-	console.error("Failed to start pnpm biome check:", err);
+	console.error("Failed to start Biome:", err);
 	process.exit(0);
 });
 


### PR DESCRIPTION
Pre-commit was brittle on Windows and in GitHub Codespaces: `biome-safe.js` spawned `pnpm.cmd` (EINVAL without shell), and `.husky/commit-msg` called `bunx commitlint`, which is not on PATH in Codespaces.

This PR:
- Runs **Biome directly** via `node` + `require.resolve("@biomejs/biome/bin/biome")`, so staged paths are passed as a normal argv list (no `shell: true`, no `cmd` quoting).
- Switches husky hooks to **`pnpm exec`** for `lint-staged` and `commitlint`, matching the repo’s package manager and fixing `bunx: not found` in CI/dev containers.

Behavior is unchanged: lint-staged still runs `biome-safe.js` on staged JS/TS/JSON files, and commitlint still validates conventional commits.
