### PR TITLE
fix: harden worker event processing and status pages

### DIFF
--- a/apps/dash/src/app/api/worker/events/route.ts
+++ b/apps/dash/src/app/api/worker/events/route.ts
@@ -7,6 +7,62 @@ import {
 import { NextResponse } from "next/server";
 import { withEvlog } from "@/lib/evlog";
 
+const MAX_EVENT_REQUEST_BYTES = 2 * 1024 * 1024;
+const MAX_EVENTS_PER_REQUEST = 1000;
+const MAX_CONCURRENT_EVENT_REQUESTS = 8;
+let activeEventRequests = 0;
+
+class EventRequestTooLargeError extends Error {}
+
+async function readJsonBody(request: Request): Promise<unknown> {
+    const contentLength = request.headers.get("content-length");
+    const declaredLength = contentLength ? Number(contentLength) : undefined;
+
+    if (
+        declaredLength !== undefined &&
+        Number.isFinite(declaredLength) &&
+        declaredLength > MAX_EVENT_REQUEST_BYTES
+    ) {
+        throw new EventRequestTooLargeError();
+    }
+
+    if (!request.body) {
+        return undefined;
+    }
+
+    const reader = request.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+
+    while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+            break;
+        }
+
+        if (!value) {
+            continue;
+        }
+
+        totalBytes += value.byteLength;
+        if (totalBytes > MAX_EVENT_REQUEST_BYTES) {
+            await reader.cancel();
+            throw new EventRequestTooLargeError();
+        }
+
+        chunks.push(value);
+    }
+
+    const bodyBytes = new Uint8Array(totalBytes);
+    let offset = 0;
+    for (const chunk of chunks) {
+        bodyBytes.set(chunk, offset);
+        offset += chunk.byteLength;
+    }
+
+    return JSON.parse(new TextDecoder().decode(bodyBytes));
+}
+
 /**
  * Handle POST requests: authenticate the worker, validate a JSON `events` array, and process monitor events.
  *
@@ -26,29 +82,75 @@ async function handlePost(request: Request) {
         );
     }
 
-    let body: { events?: MonitorEvent[] };
+    if (activeEventRequests >= MAX_CONCURRENT_EVENT_REQUESTS) {
+        return NextResponse.json(
+            { error: "Worker event processing is temporarily busy" },
+            {
+                status: 503,
+                headers: { "Retry-After": "1" },
+            },
+        );
+    }
+
+    activeEventRequests++;
+
     try {
-        body = await request.json();
-    } catch {
-        return NextResponse.json(
-            { error: "Invalid JSON body" },
-            { status: 400 },
+        let parsedBody: unknown;
+        try {
+            parsedBody = await readJsonBody(request);
+        } catch (error) {
+            if (error instanceof EventRequestTooLargeError) {
+                return NextResponse.json(
+                    {
+                        error: `Request body exceeds ${MAX_EVENT_REQUEST_BYTES} bytes`,
+                    },
+                    { status: 413 },
+                );
+            }
+
+            return NextResponse.json(
+                { error: "Invalid JSON body" },
+                { status: 400 },
+            );
+        }
+
+        if (
+            !parsedBody ||
+            typeof parsedBody !== "object" ||
+            Array.isArray(parsedBody)
+        ) {
+            return NextResponse.json(
+                { error: "Missing events array" },
+                { status: 400 },
+            );
+        }
+
+        const body = parsedBody as { events?: MonitorEvent[] };
+        if (!body.events || !Array.isArray(body.events)) {
+            return NextResponse.json(
+                { error: "Missing events array" },
+                { status: 400 },
+            );
+        }
+
+        if (body.events.length > MAX_EVENTS_PER_REQUEST) {
+            return NextResponse.json(
+                {
+                    error: `A maximum of ${MAX_EVENTS_PER_REQUEST} events may be submitted at once`,
+                },
+                { status: 413 },
+            );
+        }
+
+        const result = await processMonitorEvents(
+            body.events,
+            authResult.worker.id,
         );
+
+        return NextResponse.json(result);
+    } finally {
+        activeEventRequests--;
     }
-
-    if (!body.events || !Array.isArray(body.events)) {
-        return NextResponse.json(
-            { error: "Missing events array" },
-            { status: 400 },
-        );
-    }
-
-    const result = await processMonitorEvents(
-        body.events,
-        authResult.worker.id,
-    );
-
-    return NextResponse.json(result);
 }
 
 export const POST = withEvlog(handlePost);

--- a/apps/dash/src/status-page/lib/data-preparer.ts
+++ b/apps/dash/src/status-page/lib/data-preparer.ts
@@ -1,3 +1,4 @@
+import { getAggregateMonitorStatusesForMonitors } from "@uptimekit/api/lib/monitor-status";
 import type {
     Monitor,
     MonitorGroup,
@@ -10,7 +11,6 @@ import {
     getActiveMaintenances,
     getActiveStatusPageReports,
     getMaintenanceHistory,
-    getMonitorStatus,
     getScheduledMaintenances,
     getStatusPageEvents,
     getStatusPageReports,
@@ -205,6 +205,22 @@ export async function prepareStatusPageData(
 ): Promise<StatusPageData> {
     const design = normalizeStatusPageDesign(pageConfig.design);
     const { barDays } = design;
+    const internalMonitorInputs = [];
+    for (const pm of pageConfig.monitors) {
+        if (isExternalMonitor(pm.monitor)) {
+            continue;
+        }
+
+        internalMonitorInputs.push({
+            id: pm.monitorId,
+            workerIds: (pm.monitor.workerIds as string[] | null) ?? [],
+            locations: (pm.monitor.locations as string[] | null) ?? [],
+        });
+    }
+    const aggregateMonitorStatusesPromise =
+        internalMonitorInputs.length > 0
+            ? getAggregateMonitorStatusesForMonitors(internalMonitorInputs)
+            : Promise.resolve(new Map());
 
     const [
         activeReports,
@@ -213,6 +229,7 @@ export async function prepareStatusPageData(
         reports,
         maintenances,
         events,
+        aggregateMonitorStatuses,
     ] = await Promise.all([
         getActiveStatusPageReports(pageConfig.id),
         getActiveMaintenances(pageConfig.id),
@@ -220,6 +237,7 @@ export async function prepareStatusPageData(
         getStatusPageReports(pageConfig.id),
         getMaintenanceHistory(pageConfig.id),
         getStatusPageEvents(pageConfig.id, barDays),
+        aggregateMonitorStatusesPromise,
     ]);
 
     const combinedActive = [
@@ -342,13 +360,15 @@ export async function prepareStatusPageData(
                         (await getExternalMonitorStatus(pm.monitor)) ??
                         "unknown";
                 } else {
-                    const lastCheck = await getMonitorStatus(pm.monitorId);
-                    if (lastCheck) {
-                        if (lastCheck.status === "down")
+                    const aggregateStatus = aggregateMonitorStatuses.get(
+                        pm.monitorId,
+                    );
+                    if (aggregateStatus) {
+                        if (aggregateStatus.status === "down")
                             currentStatus = "major_outage";
-                        if (lastCheck.status === "degraded")
+                        if (aggregateStatus.status === "degraded")
                             currentStatus = "degraded";
-                        if (lastCheck.status === "maintenance")
+                        if (aggregateStatus.status === "maintenance")
                             currentStatus = "maintenance" as any;
                     }
                 }
@@ -486,7 +506,8 @@ export async function prepareStatusPageData(
                     : 100;
 
             return {
-                ...pm.monitor,
+                id: pm.monitor.id,
+                name: pm.monitor.name,
                 history,
                 avgUptime,
                 currentStatus,

--- a/apps/dash/src/status-page/lib/db-queries.ts
+++ b/apps/dash/src/status-page/lib/db-queries.ts
@@ -72,6 +72,7 @@ async function getPublishedIncidentRecords(
         limit?: number;
         cutoff?: Date;
         maintenanceOnly?: boolean;
+        sortBy?: "startedAt" | "endedAt";
     },
 ) {
     const filters = [eq(incidentStatusPage.statusPageId, statusPageId)];
@@ -110,7 +111,13 @@ async function getPublishedIncidentRecords(
         .from(incidentStatusPage)
         .innerJoin(incident, eq(incident.id, incidentStatusPage.incidentId))
         .where(and(...filters))
-        .orderBy(desc(incident.startedAt))
+        .orderBy(
+            desc(
+                options?.sortBy === "endedAt"
+                    ? incident.endedAt
+                    : incident.startedAt,
+            ),
+        )
         .$dynamic();
 
     if (options?.limit) {
@@ -124,19 +131,49 @@ async function getPublishedIncidentRecords(
     }
 
     return db.query.incidentStatusPage.findMany({
+        columns: {
+            incidentId: true,
+            statusPageId: true,
+        },
         where: and(
             eq(incidentStatusPage.statusPageId, statusPageId),
             inArray(incidentStatusPage.incidentId, incidentIds),
         ),
         with: {
             incident: {
+                columns: {
+                    id: true,
+                    title: true,
+                    status: true,
+                    severity: true,
+                    description: true,
+                    startedAt: true,
+                    plannedEndAt: true,
+                    endedAt: true,
+                    createdAt: true,
+                },
                 with: {
                     monitors: {
+                        columns: {
+                            incidentId: true,
+                            monitorId: true,
+                        },
                         with: {
-                            monitor: true,
+                            monitor: {
+                                columns: {
+                                    id: true,
+                                    name: true,
+                                },
+                            },
                         },
                     },
                     activities: {
+                        columns: {
+                            id: true,
+                            message: true,
+                            type: true,
+                            createdAt: true,
+                        },
                         orderBy: [desc(incidentActivity.createdAt)],
                     },
                 },
@@ -224,24 +261,88 @@ export type StatusPageData = NonNullable<
     Awaited<ReturnType<typeof getStatusPageByDomain>>
 >;
 
+async function getStatusPageMonitorRecords(statusPageId: string) {
+    const records = await db.query.statusPageMonitor.findMany({
+        where: eq(statusPageMonitor.statusPageId, statusPageId),
+        columns: {
+            statusPageId: true,
+            monitorId: true,
+            groupId: true,
+            style: true,
+            description: true,
+            order: true,
+        },
+        with: {
+            monitor: {
+                columns: {
+                    id: true,
+                    name: true,
+                    type: true,
+                    workerIds: true,
+                    locations: true,
+                },
+            },
+            group: {
+                columns: {
+                    id: true,
+                    name: true,
+                    order: true,
+                    collapsible: true,
+                    defaultCollapsed: true,
+                },
+            },
+        },
+        orderBy: [asc(statusPageMonitor.order)],
+    });
+
+    const externalMonitorIds: string[] = [];
+    for (const record of records) {
+        if (record.monitor.type === "instatus") {
+            externalMonitorIds.push(record.monitor.id);
+        }
+    }
+
+    if (externalMonitorIds.length === 0) {
+        return records;
+    }
+
+    const externalMonitorConfigs = await db
+        .select({ id: monitor.id, config: monitor.config })
+        .from(monitor)
+        .where(inArray(monitor.id, externalMonitorIds));
+    const configByMonitorId = new Map(
+        externalMonitorConfigs.map((record) => [record.id, record.config]),
+    );
+
+    return records.map((record) => ({
+        ...record,
+        monitor: {
+            ...record.monitor,
+            config: configByMonitorId.get(record.monitor.id) ?? null,
+        },
+    }));
+}
+
 export const getStatusPageByDomain = cache(async (domain: string) => {
     return withRetry(async () => {
         const page = await db.query.statusPage.findFirst({
             where: eq(statusPage.domain, domain),
+            columns: {
+                id: true,
+                name: true,
+                slug: true,
+                domain: true,
+                design: true,
+                public: true,
+                password: true,
+            },
         });
 
         if (!page) {
             return undefined;
         }
 
-        const monitors = await db.query.statusPageMonitor.findMany({
-            where: eq(statusPageMonitor.statusPageId, page.id),
-            with: {
-                monitor: true,
-                group: true,
-            },
-            orderBy: [asc(statusPageMonitor.order)],
-        });
+        const monitors = await getStatusPageMonitorRecords(page.id);
 
         return {
             ...page,
@@ -254,20 +355,22 @@ export const getStatusPageBySlug = cache(async (slug: string) => {
     return withRetry(async () => {
         const page = await db.query.statusPage.findFirst({
             where: eq(statusPage.slug, slug),
+            columns: {
+                id: true,
+                name: true,
+                slug: true,
+                domain: true,
+                design: true,
+                public: true,
+                password: true,
+            },
         });
 
         if (!page) {
             return undefined;
         }
 
-        const monitors = await db.query.statusPageMonitor.findMany({
-            where: eq(statusPageMonitor.statusPageId, page.id),
-            with: {
-                monitor: true,
-                group: true,
-            },
-            orderBy: [asc(statusPageMonitor.order)],
-        });
+        const monitors = await getStatusPageMonitorRecords(page.id);
 
         return {
             ...page,
@@ -356,6 +459,8 @@ export const getMaintenanceHistory = async (
             await getPublishedIncidentRecords(statusPageId, {
                 maintenanceOnly: true,
                 resolvedOnly: true,
+                sortBy: "endedAt",
+                limit,
             })
         )
             .map(mapPublishedMaintenanceRecord)
@@ -410,6 +515,8 @@ export const getMaintenanceHistoryForPeriod = async (
                 maintenanceOnly: true,
                 resolvedOnly: true,
                 cutoff: cutoff ?? undefined,
+                sortBy: "endedAt",
+                limit,
             })
         )
             .map(mapPublishedMaintenanceRecord)

--- a/apps/dash/src/status-page/lib/db-queries.ts
+++ b/apps/dash/src/status-page/lib/db-queries.ts
@@ -21,6 +21,7 @@ import {
     isNull,
     ne,
     or,
+    sql,
 } from "drizzle-orm";
 import { cache } from "react";
 import {
@@ -295,21 +296,24 @@ async function getStatusPageMonitorRecords(statusPageId: string) {
         orderBy: [asc(statusPageMonitor.order)],
     });
 
-    const externalMonitorIds: string[] = [];
-    for (const record of records) {
-        if (record.monitor.type === "instatus") {
-            externalMonitorIds.push(record.monitor.id);
-        }
-    }
+    const monitorIds = records.map((record) => record.monitor.id);
 
-    if (externalMonitorIds.length === 0) {
+    if (monitorIds.length === 0) {
         return records;
     }
 
     const externalMonitorConfigs = await db
         .select({ id: monitor.id, config: monitor.config })
         .from(monitor)
-        .where(inArray(monitor.id, externalMonitorIds));
+        .where(
+            and(
+                inArray(monitor.id, monitorIds),
+                or(
+                    eq(monitor.type, "instatus"),
+                    sql`${monitor.config}->>'componentId' IS NOT NULL`,
+                ),
+            ),
+        );
     const configByMonitorId = new Map(
         externalMonitorConfigs.map((record) => [record.id, record.config]),
     );

--- a/packages/api/src/lib/monitor-status.ts
+++ b/packages/api/src/lib/monitor-status.ts
@@ -3,6 +3,9 @@ import { incident, incidentMonitor } from "@uptimekit/db/schema/incidents";
 import { worker } from "@uptimekit/db/schema/workers";
 import { and, eq, gt, inArray, isNull, lte, or } from "drizzle-orm";
 
+type TransactionLike = Parameters<Parameters<typeof db.transaction>[0]>[0];
+type QueryableDatabase = typeof db | TransactionLike;
+
 export type MonitorRuntimeStatus =
     | "up"
     | "down"
@@ -532,9 +535,13 @@ async function getActiveMaintenanceMonitorIds(monitorIds: string[]) {
 
 export async function getEffectiveWorkersForMonitors(
     monitors: MonitorWorkerAssignment[],
-    options: { activeOnly?: boolean } = {},
+    options: {
+        activeOnly?: boolean;
+        database?: QueryableDatabase;
+    } = {},
 ) {
     const activeOnly = options.activeOnly ?? true;
+    const database = options.database ?? db;
     const explicitWorkerIds = unique(
         monitors.flatMap((monitorRecord) => monitorRecord.workerIds ?? []),
     );
@@ -548,7 +555,7 @@ export async function getEffectiveWorkersForMonitors(
 
     const [explicitWorkers, fallbackWorkers] = await Promise.all([
         explicitWorkerIds.length > 0
-            ? db
+            ? database
                   .select({
                       id: worker.id,
                       name: worker.name,
@@ -565,7 +572,7 @@ export async function getEffectiveWorkersForMonitors(
                   )
             : Promise.resolve([]),
         fallbackLocations.length > 0
-            ? db
+            ? database
                   .select({
                       id: worker.id,
                       name: worker.name,
@@ -635,7 +642,10 @@ export async function getEffectiveWorkersForMonitors(
 
 export async function getEffectiveMonitorWorkers(
     monitorRecord: MonitorWorkerAssignment,
-    options: { activeOnly?: boolean } = {},
+    options: {
+        activeOnly?: boolean;
+        database?: QueryableDatabase;
+    } = {},
 ) {
     const workersByMonitor = await getEffectiveWorkersForMonitors(
         [monitorRecord],

--- a/packages/api/src/pkg/worker/auth.ts
+++ b/packages/api/src/pkg/worker/auth.ts
@@ -24,10 +24,31 @@ interface CacheEntry {
 // TTL: 60 seconds - balances security (key revocation) vs performance
 const apiKeyCache = new Map<string, CacheEntry>();
 const CACHE_TTL_MS = 60 * 1000; // 60 seconds
+const MAX_API_KEY_CACHE_ENTRIES = 1024;
 
 // Negative cache for invalid keys (shorter TTL to limit attack window)
 const invalidKeyCache = new Map<string, number>();
 const INVALID_CACHE_TTL_MS = 10 * 1000; // 10 seconds
+const MAX_INVALID_KEY_CACHE_ENTRIES = 4096;
+
+function setBoundedCacheEntry<T>(
+    cache: Map<string, T>,
+    key: string,
+    value: T,
+    maxEntries: number,
+) {
+    // Re-inserting moves an existing entry to the newest end of the FIFO set.
+    cache.delete(key);
+    cache.set(key, value);
+
+    while (cache.size > maxEntries) {
+        const oldestKey = cache.keys().next().value;
+        if (oldestKey === undefined) {
+            break;
+        }
+        cache.delete(oldestKey);
+    }
+}
 
 /**
  * Removes expired entries from both API key caches.
@@ -48,8 +69,9 @@ function cleanupCache() {
     }
 }
 
-// Run cleanup every 30 seconds
-setInterval(cleanupCache, 30 * 1000);
+// Run cleanup every 30 seconds without keeping an otherwise idle process alive.
+const cacheCleanupInterval = setInterval(cleanupCache, 30 * 1000);
+cacheCleanupInterval.unref?.();
 
 /**
  * Compute the SHA-256 hash of an API key and return it as a lowercase hex string.
@@ -118,7 +140,12 @@ export async function authenticateWorker(
 
     if (!keyRecord?.worker) {
         // Cache invalid key
-        invalidKeyCache.set(keyHash, now + INVALID_CACHE_TTL_MS);
+        setBoundedCacheEntry(
+            invalidKeyCache,
+            keyHash,
+            now + INVALID_CACHE_TTL_MS,
+            MAX_INVALID_KEY_CACHE_ENTRIES,
+        );
         return { error: "Invalid API Key", status: 401 };
     }
 
@@ -126,7 +153,12 @@ export async function authenticateWorker(
 
     if (!workerRecord.active) {
         // Cache as invalid (worker inactive)
-        invalidKeyCache.set(keyHash, now + INVALID_CACHE_TTL_MS);
+        setBoundedCacheEntry(
+            invalidKeyCache,
+            keyHash,
+            now + INVALID_CACHE_TTL_MS,
+            MAX_INVALID_KEY_CACHE_ENTRIES,
+        );
         return { error: "Worker not found or inactive", status: 401 };
     }
 
@@ -141,10 +173,15 @@ export async function authenticateWorker(
     };
 
     // Cache the result
-    apiKeyCache.set(keyHash, {
-        workerContext: result,
-        expiresAt: now + CACHE_TTL_MS,
-    });
+    setBoundedCacheEntry(
+        apiKeyCache,
+        keyHash,
+        {
+            workerContext: result,
+            expiresAt: now + CACHE_TTL_MS,
+        },
+        MAX_API_KEY_CACHE_ENTRIES,
+    );
 
     // Update heartbeat and last used timestamp
     await Promise.all([

--- a/packages/api/src/pkg/worker/service.test.ts
+++ b/packages/api/src/pkg/worker/service.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
     getConfiguredWorkerStates,
+    getStableMonitorEventId,
     isAutomaticIncidentOpenEligible,
     isAutomaticIncidentResolveEligible,
     type MonitorEvent,
@@ -308,5 +309,41 @@ describe("worker automatic incident gating", () => {
         });
 
         expect(result.eligible).toBe(false);
+    });
+});
+
+describe("worker event retry identity", () => {
+    it("derives the same UUID for a replayed legacy event", () => {
+        const event = {
+            monitorId: "monitor-1",
+            status: "down" as const,
+            latency: 0,
+            timestamp: "2026-04-26T10:00:00Z",
+            error: "connection refused",
+            location: "worker-a",
+        };
+
+        const firstId = getStableMonitorEventId(event, "worker-a");
+        const replayId = getStableMonitorEventId({ ...event }, "worker-a");
+
+        expect(firstId).toBe(replayId);
+        expect(firstId).toMatch(
+            /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+        );
+    });
+
+    it("normalizes a supplied source id without generating a new id", () => {
+        const id = "550E8400-E29B-41D4-A716-446655440000";
+        const event = {
+            id,
+            monitorId: "monitor-1",
+            status: "up" as const,
+            latency: 25,
+            timestamp: "2026-04-26T10:00:00Z",
+        };
+
+        expect(getStableMonitorEventId(event, "worker-a")).toBe(
+            id.toLowerCase(),
+        );
     });
 });

--- a/packages/api/src/pkg/worker/service.ts
+++ b/packages/api/src/pkg/worker/service.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { db, timeseries } from "@uptimekit/db";
 import {
     incident,
@@ -33,6 +34,8 @@ export interface HTTPTimings {
 }
 
 export interface MonitorEvent {
+    /** Optional source id. When absent, the API derives a retry-stable id. */
+    id?: string;
     monitorId: string;
     status: "up" | "down" | "degraded" | "maintenance" | "pending";
     latency: number;
@@ -79,6 +82,70 @@ type WorkerIncidentEventDispatch =
 const monitorEventLocks = new Map<string, Promise<void>>();
 type TransactionLike = Parameters<Parameters<typeof db.transaction>[0]>[0];
 type AutomaticIncidentTriggerStatus = "down" | "degraded";
+
+const UUID_PATTERN =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function createDeterministicUuid(value: string) {
+    const bytes = createHash("sha256").update(value).digest();
+    bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x40;
+    bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
+
+    const hex = bytes.toString("hex");
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(
+        12,
+        16,
+    )}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+}
+
+/**
+ * Return the time-series identity for a worker event.
+ *
+ * Worker retries resend the same payload, so this must not depend on a
+ * request attempt or on the relational transaction result. Source ids are
+ * preferred; older workers do not send one, so their event fields form a
+ * deterministic fallback identity.
+ */
+function getStableMonitorEventId(event: MonitorEvent, workerId: string) {
+    const sourceId = event.id?.trim();
+    if (sourceId) {
+        return UUID_PATTERN.test(sourceId)
+            ? sourceId.toLowerCase()
+            : createDeterministicUuid(
+                  [
+                      "uptimekit-monitor-event",
+                      workerId,
+                      event.monitorId,
+                      sourceId,
+                  ].join("\u001f"),
+              );
+    }
+
+    const parsedTimestamp = new Date(event.timestamp);
+    const timestamp = Number.isNaN(parsedTimestamp.getTime())
+        ? String(event.timestamp)
+        : parsedTimestamp.toISOString();
+    const eventLocation = event.location || workerId;
+
+    return createDeterministicUuid(
+        [
+            "uptimekit-monitor-event",
+            workerId,
+            event.monitorId,
+            eventLocation,
+            timestamp,
+            event.status,
+            event.latency,
+            event.statusCode ?? "",
+            event.error ?? "",
+            event.timings?.dnsLookup ?? "",
+            event.timings?.tcpConnect ?? "",
+            event.timings?.tlsHandshake ?? "",
+            event.timings?.ttfb ?? "",
+            event.timings?.transfer ?? "",
+        ].join("\u001f"),
+    );
+}
 
 function getAutomaticIncidentTitle(
     monitorName: string,
@@ -247,7 +314,7 @@ async function persistProcessedMonitorEventTimeSeries(input: {
     if (monitorEvents.length > 0) {
         await timeseries.insertMonitorEvents(
             monitorEvents.map((event) => ({
-                id: crypto.randomUUID(),
+                id: getStableMonitorEventId(event, workerId),
                 monitorId: event.monitorId,
                 status: event.status,
                 latency: event.latency,
@@ -269,6 +336,7 @@ export {
     type AutomaticIncidentOpenEvaluation,
     type ConfiguredWorkerStateResult,
     getConfiguredWorkerStates,
+    getStableMonitorEventId,
     isAutomaticIncidentOpenEligible,
     isAutomaticIncidentResolveEligible,
     type WorkerStatusSnapshot,
@@ -368,9 +436,14 @@ export async function processMonitorEvents(
     events: MonitorEvent[],
     workerId: string,
 ) {
+    const eventsWithStableIds = events.map((event) => ({
+        ...event,
+        id: getStableMonitorEventId(event, workerId),
+    }));
+
     // Group events by monitor
     const eventsByMonitor = new Map<string, MonitorEvent[]>();
-    for (const event of events) {
+    for (const event of eventsWithStableIds) {
         const list = eventsByMonitor.get(event.monitorId) || [];
         list.push(event);
         eventsByMonitor.set(event.monitorId, list);
@@ -568,7 +641,7 @@ async function processMonitorEventGroup(input: {
 
         if (isChange || isFirstEvent) {
             result.changesToInsert.push({
-                id: crypto.randomUUID(),
+                id: getStableMonitorEventId(event, workerId),
                 monitorId: event.monitorId,
                 status: aggregateRuntimeStatus,
                 timestamp: eventTime,

--- a/packages/api/src/pkg/worker/service.ts
+++ b/packages/api/src/pkg/worker/service.ts
@@ -392,15 +392,15 @@ export async function processMonitorEvents(
                     tx,
                 });
 
+                return processedGroup;
+            },
+            async (processedGroup) => {
                 await persistProcessedMonitorEventTimeSeries({
                     processed: processedGroup,
                     monitorEvents,
                     workerId,
                 });
 
-                return processedGroup;
-            },
-            async (processedGroup) => {
                 if (processedGroup.eventsToDispatch.length > 0) {
                     await processPendingNotifications("worker-events");
                 }

--- a/packages/api/src/pkg/worker/service.ts
+++ b/packages/api/src/pkg/worker/service.ts
@@ -1,4 +1,4 @@
-import { db, postgresClient, timeseries } from "@uptimekit/db";
+import { db, timeseries } from "@uptimekit/db";
 import {
     incident,
     incidentActivity,
@@ -8,7 +8,7 @@ import {
 import { monitor } from "@uptimekit/db/schema/monitors";
 import { statusPageMonitor } from "@uptimekit/db/schema/status-pages";
 import { worker } from "@uptimekit/db/schema/workers";
-import { and, eq, gt, isNull, lte, or } from "drizzle-orm";
+import { and, eq, gt, isNull, lte, or, sql } from "drizzle-orm";
 import { type AppEventPayload, publishAppEvent } from "../../lib/events";
 import {
     type AutomaticIncidentOpenEvaluation,
@@ -77,6 +77,7 @@ type WorkerIncidentEventDispatch =
       };
 
 const monitorEventLocks = new Map<string, Promise<void>>();
+type TransactionLike = Parameters<Parameters<typeof db.transaction>[0]>[0];
 type AutomaticIncidentTriggerStatus = "down" | "degraded";
 
 function getAutomaticIncidentTitle(
@@ -151,7 +152,8 @@ function getAutomaticIncidentEscalatedMessage(input: {
 
 async function withMonitorEventLock<T>(
     monitorId: string,
-    fn: () => Promise<T>,
+    fn: (tx: TransactionLike) => Promise<T>,
+    afterCommit?: (result: T) => Promise<void>,
 ) {
     const previous = monitorEventLocks.get(monitorId) ?? Promise.resolve();
     let releaseCurrentLock: () => void = () => {};
@@ -164,10 +166,18 @@ async function withMonitorEventLock<T>(
     await previous.catch(() => undefined);
 
     try {
-        return await postgresClient.begin(async (sql) => {
-            await sql`select pg_advisory_xact_lock(hashtextextended(${monitorId}, 0))`;
-            return fn();
+        const result = await db.transaction(async (tx) => {
+            await tx.execute(
+                sql`select pg_advisory_xact_lock(hashtextextended(${monitorId}, 0))`,
+            );
+            return fn(tx);
         });
+
+        if (afterCommit) {
+            await afterCommit(result);
+        }
+
+        return result;
     } finally {
         releaseCurrentLock();
         if (monitorEventLocks.get(monitorId) === tail) {
@@ -178,6 +188,53 @@ async function withMonitorEventLock<T>(
 
 async function persistProcessedMonitorEventGroup(input: {
     processed: ProcessedMonitorEventGroup;
+    tx: TransactionLike;
+}) {
+    const { processed, tx } = input;
+
+    if (processed.incidentsToInsert.length > 0) {
+        await tx.insert(incident).values(processed.incidentsToInsert);
+    }
+
+    for (const update of processed.incidentUpdatesToApply) {
+        await tx
+            .update(incident)
+            .set(update.values)
+            .where(eq(incident.id, update.id));
+    }
+
+    if (processed.incidentMonitorsToInsert.length > 0) {
+        await tx
+            .insert(incidentMonitor)
+            .values(processed.incidentMonitorsToInsert);
+    }
+
+    if (processed.incidentStatusPagesToInsert.length > 0) {
+        await tx
+            .insert(incidentStatusPage)
+            .values(processed.incidentStatusPagesToInsert);
+    }
+
+    if (processed.activitiesToInsert.length > 0) {
+        await tx.insert(incidentActivity).values(processed.activitiesToInsert);
+    }
+
+    for (const eventToDispatch of processed.eventsToDispatch) {
+        if (eventToDispatch.event === "incident.created") {
+            await publishAppEvent("incident.created", eventToDispatch.payload, {
+                tx,
+            });
+            continue;
+        }
+
+        await publishAppEvent("incident.resolved", eventToDispatch.payload, {
+            tx,
+        });
+    }
+}
+
+async function persistProcessedMonitorEventTimeSeries(input: {
+    processed: ProcessedMonitorEventGroup;
     monitorEvents: MonitorEvent[];
     workerId: string;
 }) {
@@ -185,62 +242,6 @@ async function persistProcessedMonitorEventGroup(input: {
 
     if (processed.changesToInsert.length > 0) {
         await timeseries.insertMonitorChanges(processed.changesToInsert);
-    }
-
-    await db.transaction(async (tx) => {
-        if (processed.incidentsToInsert.length > 0) {
-            await tx.insert(incident).values(processed.incidentsToInsert);
-        }
-
-        for (const update of processed.incidentUpdatesToApply) {
-            await tx
-                .update(incident)
-                .set(update.values)
-                .where(eq(incident.id, update.id));
-        }
-
-        if (processed.incidentMonitorsToInsert.length > 0) {
-            await tx
-                .insert(incidentMonitor)
-                .values(processed.incidentMonitorsToInsert);
-        }
-
-        if (processed.incidentStatusPagesToInsert.length > 0) {
-            await tx
-                .insert(incidentStatusPage)
-                .values(processed.incidentStatusPagesToInsert);
-        }
-
-        if (processed.activitiesToInsert.length > 0) {
-            await tx
-                .insert(incidentActivity)
-                .values(processed.activitiesToInsert);
-        }
-
-        for (const eventToDispatch of processed.eventsToDispatch) {
-            if (eventToDispatch.event === "incident.created") {
-                await publishAppEvent(
-                    "incident.created",
-                    eventToDispatch.payload,
-                    {
-                        tx,
-                    },
-                );
-                continue;
-            }
-
-            await publishAppEvent(
-                "incident.resolved",
-                eventToDispatch.payload,
-                {
-                    tx,
-                },
-            );
-        }
-    });
-
-    if (processed.eventsToDispatch.length > 0) {
-        await processPendingNotifications("worker-events");
     }
 
     if (monitorEvents.length > 0) {
@@ -282,66 +283,78 @@ export {
 export async function getMonitorsForWorker(workerId: string) {
     const workerRecord = await db.query.worker.findFirst({
         where: eq(worker.id, workerId),
+        columns: {
+            location: true,
+        },
     });
 
     if (!workerRecord) {
         return [];
     }
 
-    const allActiveMonitors = await db.query.monitor.findMany({
-        where: (t, { eq }) => eq(t.active, true),
+    const assignedActiveMonitors = await db.query.monitor.findMany({
+        where: and(
+            eq(monitor.active, true),
+            or(
+                sql`${monitor.workerIds}::jsonb @> ${JSON.stringify([workerId])}::jsonb`,
+                and(
+                    sql`coalesce(${monitor.workerIds}::jsonb, '[]'::jsonb) = '[]'::jsonb`,
+                    sql`${monitor.locations}::jsonb @> ${JSON.stringify([workerRecord.location])}::jsonb`,
+                ),
+            ),
+        ),
+        columns: {
+            id: true,
+            type: true,
+            interval: true,
+            timeout: true,
+            retries: true,
+            retryInterval: true,
+            config: true,
+        },
     });
 
-    return allActiveMonitors
-        .filter((m) => {
-            const workerIds = (m.workerIds as string[] | null) ?? [];
-            if (workerIds.length > 0) {
-                return workerIds.includes(workerId);
-            }
-            const locations = (m.locations as string[] | null) ?? [];
-            return locations.includes(workerRecord.location);
-        })
-        .map((m) => {
-            const config = m.config as {
-                url?: string;
-                hostname?: string;
-                port?: number;
-                resolverServers?: string;
-                recordType?: string;
-                method?: string;
-                headers?: Record<string, string>;
-                body?: string;
-                acceptedStatusCodes?: string;
-                keyword?: string;
-                jsonPath?: string;
-                expectedValue?: string;
-                checkSsl?: boolean;
-                sslCertExpiryNotificationDays?: number;
-            };
-            return {
-                id: m.id,
-                type: m.type,
-                url: config.url || "",
-                hostname: config.hostname || "",
-                port: config.port || 0,
-                resolverServers: config.resolverServers || "",
-                recordType: config.recordType || "",
-                interval: m.interval,
-                timeout: m.timeout,
-                retries: m.retries,
-                retryInterval: m.retryInterval,
-                method: config.method || "GET",
-                headers: config.headers || {},
-                body: config.body,
-                acceptedStatusCodes: config.acceptedStatusCodes,
-                keyword: config.keyword,
-                jsonPath: config.jsonPath,
-                expectedValue: config.expectedValue,
-                checkSsl: config.checkSsl ?? true,
-                sslCertExpiryNotificationDays:
-                    config.sslCertExpiryNotificationDays ?? 30,
-            };
-        });
+    return assignedActiveMonitors.map((m) => {
+        const config = m.config as {
+            url?: string;
+            hostname?: string;
+            port?: number;
+            resolverServers?: string;
+            recordType?: string;
+            method?: string;
+            headers?: Record<string, string>;
+            body?: string;
+            acceptedStatusCodes?: string;
+            keyword?: string;
+            jsonPath?: string;
+            expectedValue?: string;
+            checkSsl?: boolean;
+            sslCertExpiryNotificationDays?: number;
+        };
+        return {
+            id: m.id,
+            type: m.type,
+            url: config.url || "",
+            hostname: config.hostname || "",
+            port: config.port || 0,
+            resolverServers: config.resolverServers || "",
+            recordType: config.recordType || "",
+            interval: m.interval,
+            timeout: m.timeout,
+            retries: m.retries,
+            retryInterval: m.retryInterval,
+            method: config.method || "GET",
+            headers: config.headers || {},
+            body: config.body,
+            acceptedStatusCodes: config.acceptedStatusCodes,
+            keyword: config.keyword,
+            jsonPath: config.jsonPath,
+            expectedValue: config.expectedValue,
+            checkSsl: config.checkSsl ?? true,
+            sslCertExpiryNotificationDays:
+                config.sslCertExpiryNotificationDays ?? 30,
+        };
+    });
 }
 
 /**
@@ -364,21 +377,35 @@ export async function processMonitorEvents(
     }
 
     for (const [monitorId, monitorEvents] of eventsByMonitor.entries()) {
-        await withMonitorEventLock(monitorId, async () => {
-            const processedGroup = await processMonitorEventGroup(
-                monitorId,
-                monitorEvents,
-                workerId,
-            );
+        await withMonitorEventLock(
+            monitorId,
+            async (tx) => {
+                const processedGroup = await processMonitorEventGroup({
+                    monitorId,
+                    monitorEvents,
+                    workerId,
+                    tx,
+                });
 
-            await persistProcessedMonitorEventGroup({
-                processed: processedGroup,
-                monitorEvents,
-                workerId,
-            });
+                await persistProcessedMonitorEventGroup({
+                    processed: processedGroup,
+                    tx,
+                });
 
-            return processedGroup;
-        });
+                await persistProcessedMonitorEventTimeSeries({
+                    processed: processedGroup,
+                    monitorEvents,
+                    workerId,
+                });
+
+                return processedGroup;
+            },
+            async (processedGroup) => {
+                if (processedGroup.eventsToDispatch.length > 0) {
+                    await processPendingNotifications("worker-events");
+                }
+            },
+        );
     }
 
     return { success: true, count: events.length };
@@ -389,19 +416,15 @@ export async function processMonitorEvents(
  * opening or resolving automatic incidents based on the monitor's pending duration,
  * and recording incident-monitor mappings and incident activities. May emit incident events and update incident rows in the database.
  *
- * @param monitorId - ID of the monitor whose events are being processed
- * @param monitorEvents - Chronologically ordered (will be sorted if not) events for the monitor
- * @param workerLocation - Location identifier of the worker processing the events; used as a fallback event location
- * @param changesToInsert - Array that will be appended with MonitorChangeInsert entries to persist monitor status changes
- * @param incidentsToInsert - Array that will be appended with incident insert objects for newly created automatic incidents
- * @param incidentMonitorsToInsert - Array that will be appended with incident-monitor mapping entries for new incidents
- * @param activitiesToInsert - Array that will be appended with incident activity entries describing automated actions
+ * @param input - Monitor event data and the transaction-scoped database client
  */
-async function processMonitorEventGroup(
-    monitorId: string,
-    monitorEvents: MonitorEvent[],
-    workerId: string,
-): Promise<ProcessedMonitorEventGroup> {
+async function processMonitorEventGroup(input: {
+    monitorId: string;
+    monitorEvents: MonitorEvent[];
+    workerId: string;
+    tx: TransactionLike;
+}): Promise<ProcessedMonitorEventGroup> {
+    const { monitorId, monitorEvents, workerId, tx } = input;
     const result: ProcessedMonitorEventGroup = {
         changesToInsert: [],
         incidentsToInsert: [],
@@ -412,7 +435,7 @@ async function processMonitorEventGroup(
         eventsToDispatch: [],
     };
 
-    const monitorConfig = await db.query.monitor.findFirst({
+    const monitorConfig = await tx.query.monitor.findFirst({
         where: eq(monitor.id, monitorId),
     });
 
@@ -422,7 +445,7 @@ async function processMonitorEventGroup(
     }
 
     const now = new Date();
-    const activeMaintenance = await db
+    const activeMaintenance = await tx
         .select({ id: incident.id })
         .from(incident)
         .innerJoin(incidentMonitor, eq(incident.id, incidentMonitor.incidentId))
@@ -449,7 +472,7 @@ async function processMonitorEventGroup(
     }
 
     // Fetch active automatic incident
-    const activeIncidentList = await db
+    const activeIncidentList = await tx
         .select({
             id: incident.id,
             status: incident.status,
@@ -485,11 +508,14 @@ async function processMonitorEventGroup(
     const monitorLocations = Array.isArray(monitorConfig.locations)
         ? monitorConfig.locations
         : [];
-    const configuredWorkers = await getEffectiveMonitorWorkers({
-        id: monitorConfig.id,
-        workerIds: monitorWorkerIds,
-        locations: monitorLocations,
-    });
+    const configuredWorkers = await getEffectiveMonitorWorkers(
+        {
+            id: monitorConfig.id,
+            workerIds: monitorWorkerIds,
+            locations: monitorLocations,
+        },
+        { database: tx },
+    );
     const configuredWorkerIds = configuredWorkers.map(
         (configuredWorker) => configuredWorker.id,
     );
@@ -718,7 +744,7 @@ async function processMonitorEventGroup(
             });
 
             if (monitorConfig.publishIncidentToStatusPage) {
-                const statusPages = await db
+                const statusPages = await tx
                     .select({
                         statusPageId: statusPageMonitor.statusPageId,
                     })

--- a/packages/api/src/routers/monitors.ts
+++ b/packages/api/src/routers/monitors.ts
@@ -74,6 +74,7 @@ const MONITOR_TYPES = [
 ] as const;
 const URL_MONITOR_TYPES = new Set(["http", "http-json", "keyword", "instatus"]);
 const EXTERNAL_COMPONENTS_CACHE_TTL_MS = 60_000;
+const EXTERNAL_COMPONENTS_CACHE_MAX_ENTRIES = 64;
 const EXTERNAL_COMPONENTS_MAX_BODY_BYTES = 1024 * 1024;
 
 interface InstatusComponentResponse {
@@ -233,6 +234,15 @@ async function listInstatusComponents(statusPageUrl: string) {
 
     const componentsUrl = getInstatusComponentsUrl(statusPageUrl);
     const now = Date.now();
+
+    if (externalComponentsCache) {
+        for (const [url, entry] of externalComponentsCache) {
+            if (entry.expiresAt <= now) {
+                externalComponentsCache.delete(url);
+            }
+        }
+    }
+
     const cached = externalComponentsCache?.get(componentsUrl);
     if (cached && cached.expiresAt > now) {
         return cached.components;
@@ -292,10 +302,21 @@ async function listInstatusComponents(statusPageUrl: string) {
         });
 
     externalComponentsCache ??= new Map();
+    externalComponentsCache.delete(componentsUrl);
     externalComponentsCache.set(componentsUrl, {
         expiresAt: now + EXTERNAL_COMPONENTS_CACHE_TTL_MS,
         components,
     });
+
+    while (
+        externalComponentsCache.size > EXTERNAL_COMPONENTS_CACHE_MAX_ENTRIES
+    ) {
+        const oldestUrl = externalComponentsCache.keys().next().value;
+        if (oldestUrl === undefined) {
+            break;
+        }
+        externalComponentsCache.delete(oldestUrl);
+    }
 
     return components;
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -7,7 +7,7 @@ import { createTimeSeriesDriver } from "./timeseries";
 loadEnv();
 
 const client = postgres(process.env.DATABASE_URL || "", {
-    max: 20,
+    max: 10,
     idle_timeout: 30,
 });
 

--- a/packages/db/src/timeseries/clickhouse.ts
+++ b/packages/db/src/timeseries/clickhouse.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { type ClickHouseClient, createClient } from "@clickhouse/client";
 import type { TimeSeriesBackend, TimeSeriesDriver } from "./driver";
 import type {
@@ -26,6 +27,10 @@ interface BootstrapQuery {
         table: string;
     };
 }
+
+type ClickHouseTimeSeriesTable =
+    | "uptimekit.monitor_events"
+    | "uptimekit.monitor_changes";
 
 const BOOTSTRAP_QUERIES: BootstrapQuery[] = [
     { query: "CREATE DATABASE IF NOT EXISTS uptimekit" },
@@ -108,6 +113,17 @@ function getQuantileLevel(value: number | undefined) {
         );
     }
     return quantile.toString();
+}
+
+function getInsertDeduplicationToken(rows: Array<{ id: string }>) {
+    return createHash("sha256")
+        .update(
+            rows
+                .map((row) => row.id.toLowerCase())
+                .sort()
+                .join("\n"),
+        )
+        .digest("hex");
 }
 
 export interface ClickHouseDriverOptions {
@@ -223,14 +239,46 @@ export class ClickHouseDriver implements TimeSeriesDriver {
         return json.data;
     }
 
+    private async filterExistingRows<T extends { id: string }>(
+        table: ClickHouseTimeSeriesTable,
+        rows: T[],
+    ) {
+        const uniqueRows = Array.from(
+            new Map(rows.map((row) => [row.id.toLowerCase(), row])).values(),
+        );
+        if (uniqueRows.length === 0) return uniqueRows;
+
+        const existingRows = await this.queryJson<{ id: string }>(
+            `
+                SELECT toString(id) AS id
+                FROM ${table}
+                WHERE toString(id) IN ({ids:Array(String)})
+            `,
+            { ids: uniqueRows.map((row) => row.id) },
+        );
+        const existingIds = new Set(
+            existingRows.map((row) => row.id.toLowerCase()),
+        );
+
+        return uniqueRows.filter(
+            (row) => !existingIds.has(row.id.toLowerCase()),
+        );
+    }
+
     async insertMonitorEvents(events: MonitorEventInsert[]) {
         if (events.length === 0) return;
 
         await this.ensureSchema();
 
+        const newEvents = await this.filterExistingRows(
+            "uptimekit.monitor_events",
+            events,
+        );
+        if (newEvents.length === 0) return;
+
         await this.getClient().insert({
             table: "uptimekit.monitor_events",
-            values: events.map((e) => ({
+            values: newEvents.map((e) => ({
                 id: e.id,
                 monitorId: e.monitorId,
                 status: e.status,
@@ -246,6 +294,11 @@ export class ClickHouseDriver implements TimeSeriesDriver {
                 transfer: e.transfer ?? null,
             })),
             format: "JSONEachRow",
+            clickhouse_settings: {
+                insert_deduplicate: 1,
+                insert_deduplication_token:
+                    getInsertDeduplicationToken(newEvents),
+            },
         });
     }
 
@@ -254,9 +307,15 @@ export class ClickHouseDriver implements TimeSeriesDriver {
 
         await this.ensureSchema();
 
+        const newChanges = await this.filterExistingRows(
+            "uptimekit.monitor_changes",
+            changes,
+        );
+        if (newChanges.length === 0) return;
+
         await this.getClient().insert({
             table: "uptimekit.monitor_changes",
-            values: changes.map((c) => ({
+            values: newChanges.map((c) => ({
                 id: c.id,
                 monitorId: c.monitorId,
                 status: c.status,
@@ -264,6 +323,11 @@ export class ClickHouseDriver implements TimeSeriesDriver {
                 location: c.location ?? null,
             })),
             format: "JSONEachRow",
+            clickhouse_settings: {
+                insert_deduplicate: 1,
+                insert_deduplication_token:
+                    getInsertDeduplicationToken(newChanges),
+            },
         });
     }
 

--- a/packages/db/src/timeseries/clickhouse.ts
+++ b/packages/db/src/timeseries/clickhouse.ts
@@ -32,6 +32,9 @@ type ClickHouseTimeSeriesTable =
     | "uptimekit.monitor_events"
     | "uptimekit.monitor_changes";
 
+const CLICKHOUSE_DEDUPLICATION_WINDOW = 10_000;
+const CLICKHOUSE_INSERT_CONCURRENCY = 8;
+
 const BOOTSTRAP_QUERIES: BootstrapQuery[] = [
     { query: "CREATE DATABASE IF NOT EXISTS uptimekit" },
     {
@@ -50,9 +53,10 @@ const BOOTSTRAP_QUERIES: BootstrapQuery[] = [
 				tlsHandshake Nullable(UInt32),
 				ttfb Nullable(UInt32),
 				transfer Nullable(UInt32)
-			) ENGINE = MergeTree()
-			ORDER BY (monitorId, timestamp)
-		`,
+				) ENGINE = MergeTree()
+				ORDER BY (monitorId, timestamp)
+				SETTINGS non_replicated_deduplication_window = ${CLICKHOUSE_DEDUPLICATION_WINDOW}
+			`,
     },
     {
         query: `
@@ -62,9 +66,22 @@ const BOOTSTRAP_QUERIES: BootstrapQuery[] = [
 				status String,
 				timestamp DateTime64(3),
 				location Nullable(String)
-			) ENGINE = MergeTree()
-			ORDER BY (monitorId, timestamp)
-		`,
+				) ENGINE = MergeTree()
+				ORDER BY (monitorId, timestamp)
+				SETTINGS non_replicated_deduplication_window = ${CLICKHOUSE_DEDUPLICATION_WINDOW}
+			`,
+    },
+    {
+        query: `
+            ALTER TABLE uptimekit.monitor_events
+            MODIFY SETTING non_replicated_deduplication_window = ${CLICKHOUSE_DEDUPLICATION_WINDOW}
+        `,
+    },
+    {
+        query: `
+            ALTER TABLE uptimekit.monitor_changes
+            MODIFY SETTING non_replicated_deduplication_window = ${CLICKHOUSE_DEDUPLICATION_WINDOW}
+        `,
     },
     {
         query: "ALTER TABLE system.query_log MODIFY TTL event_date + INTERVAL 3 DAY",
@@ -115,14 +132,9 @@ function getQuantileLevel(value: number | undefined) {
     return quantile.toString();
 }
 
-function getInsertDeduplicationToken(rows: Array<{ id: string }>) {
+function getInsertDeduplicationToken(id: string) {
     return createHash("sha256")
-        .update(
-            rows
-                .map((row) => row.id.toLowerCase())
-                .sort()
-                .join("\n"),
-        )
+        .update(`uptimekit-timeseries-row\u001f${id.toLowerCase()}`)
         .digest("hex");
 }
 
@@ -265,6 +277,33 @@ export class ClickHouseDriver implements TimeSeriesDriver {
         );
     }
 
+    private async insertRowsIndividually<T extends { id: string }>(
+        rows: T[],
+        insert: (row: T) => Promise<void>,
+    ) {
+        let nextIndex = 0;
+        const insertNextRow = async () => {
+            while (true) {
+                const row = rows[nextIndex];
+                nextIndex += 1;
+                if (!row) return;
+                await insert(row);
+            }
+        };
+
+        await Promise.all(
+            Array.from(
+                {
+                    length: Math.min(
+                        CLICKHOUSE_INSERT_CONCURRENCY,
+                        rows.length,
+                    ),
+                },
+                () => insertNextRow(),
+            ),
+        );
+    }
+
     async insertMonitorEvents(events: MonitorEventInsert[]) {
         if (events.length === 0) return;
 
@@ -276,29 +315,37 @@ export class ClickHouseDriver implements TimeSeriesDriver {
         );
         if (newEvents.length === 0) return;
 
-        await this.getClient().insert({
-            table: "uptimekit.monitor_events",
-            values: newEvents.map((e) => ({
-                id: e.id,
-                monitorId: e.monitorId,
-                status: e.status,
-                latency: e.latency,
-                timestamp: e.timestamp.getTime(),
-                statusCode: e.statusCode ?? null,
-                error: e.error ?? null,
-                location: e.location ?? null,
-                dnsLookup: e.dnsLookup ?? null,
-                tcpConnect: e.tcpConnect ?? null,
-                tlsHandshake: e.tlsHandshake ?? null,
-                ttfb: e.ttfb ?? null,
-                transfer: e.transfer ?? null,
-            })),
-            format: "JSONEachRow",
-            clickhouse_settings: {
-                insert_deduplicate: 1,
-                insert_deduplication_token:
-                    getInsertDeduplicationToken(newEvents),
-            },
+        // The existence query is only a fast path for known replays. Each row
+        // still gets its own deduplication token because concurrent requests
+        // can observe the same missing id before either insert completes.
+        await this.insertRowsIndividually(newEvents, async (event) => {
+            await this.getClient().insert({
+                table: "uptimekit.monitor_events",
+                values: [
+                    {
+                        id: event.id,
+                        monitorId: event.monitorId,
+                        status: event.status,
+                        latency: event.latency,
+                        timestamp: event.timestamp.getTime(),
+                        statusCode: event.statusCode ?? null,
+                        error: event.error ?? null,
+                        location: event.location ?? null,
+                        dnsLookup: event.dnsLookup ?? null,
+                        tcpConnect: event.tcpConnect ?? null,
+                        tlsHandshake: event.tlsHandshake ?? null,
+                        ttfb: event.ttfb ?? null,
+                        transfer: event.transfer ?? null,
+                    },
+                ],
+                format: "JSONEachRow",
+                clickhouse_settings: {
+                    insert_deduplicate: 1,
+                    insert_deduplication_token: getInsertDeduplicationToken(
+                        event.id,
+                    ),
+                },
+            });
         });
     }
 
@@ -313,21 +360,26 @@ export class ClickHouseDriver implements TimeSeriesDriver {
         );
         if (newChanges.length === 0) return;
 
-        await this.getClient().insert({
-            table: "uptimekit.monitor_changes",
-            values: newChanges.map((c) => ({
-                id: c.id,
-                monitorId: c.monitorId,
-                status: c.status,
-                timestamp: c.timestamp.getTime(),
-                location: c.location ?? null,
-            })),
-            format: "JSONEachRow",
-            clickhouse_settings: {
-                insert_deduplicate: 1,
-                insert_deduplication_token:
-                    getInsertDeduplicationToken(newChanges),
-            },
+        await this.insertRowsIndividually(newChanges, async (change) => {
+            await this.getClient().insert({
+                table: "uptimekit.monitor_changes",
+                values: [
+                    {
+                        id: change.id,
+                        monitorId: change.monitorId,
+                        status: change.status,
+                        timestamp: change.timestamp.getTime(),
+                        location: change.location ?? null,
+                    },
+                ],
+                format: "JSONEachRow",
+                clickhouse_settings: {
+                    insert_deduplicate: 1,
+                    insert_deduplication_token: getInsertDeduplicationToken(
+                        change.id,
+                    ),
+                },
+            });
         });
     }
 

--- a/packages/db/src/timeseries/driver-suite.ts
+++ b/packages/db/src/timeseries/driver-suite.ts
@@ -290,6 +290,46 @@ export function defineDriverTests(
                 expect(events).toHaveLength(1);
                 expect(changes).toHaveLength(1);
             });
+
+            it("does not duplicate an event in concurrent differently batched retries", async () => {
+                const driver = getDriver();
+                const monitorId = uid("concurrent-retry");
+                const baseTimestamp = new Date();
+                const sharedEvent = {
+                    id: crypto.randomUUID(),
+                    monitorId,
+                    status: "up",
+                    latency: 100,
+                    timestamp: baseTimestamp,
+                };
+                const firstCompanion = {
+                    id: crypto.randomUUID(),
+                    monitorId,
+                    status: "down",
+                    latency: 0,
+                    timestamp: new Date(baseTimestamp.getTime() + 1000),
+                };
+                const secondCompanion = {
+                    id: crypto.randomUUID(),
+                    monitorId,
+                    status: "up",
+                    latency: 120,
+                    timestamp: new Date(baseTimestamp.getTime() + 2000),
+                };
+
+                await Promise.all([
+                    driver.insertMonitorEvents([sharedEvent, firstCompanion]),
+                    driver.insertMonitorEvents([sharedEvent, secondCompanion]),
+                ]);
+
+                const events = await driver.getResponseTimes({
+                    monitorId,
+                    since: new Date(baseTimestamp.getTime() - 1000),
+                    limit: null,
+                });
+
+                expect(events).toHaveLength(3);
+            });
         });
 
         describe("aggregations", () => {

--- a/packages/db/src/timeseries/driver-suite.ts
+++ b/packages/db/src/timeseries/driver-suite.ts
@@ -253,6 +253,45 @@ export function defineDriverTests(
             });
         });
 
+        describe("retry safety", () => {
+            it("does not duplicate events or changes when an insert is replayed", async () => {
+                const driver = getDriver();
+                const monitorId = uid("retry-safe");
+                const timestamp = new Date();
+                const event = {
+                    id: crypto.randomUUID(),
+                    monitorId,
+                    status: "down",
+                    latency: 0,
+                    timestamp,
+                };
+                const change = {
+                    id: crypto.randomUUID(),
+                    monitorId,
+                    status: "down",
+                    timestamp,
+                };
+
+                await driver.insertMonitorEvents([event]);
+                await driver.insertMonitorEvents([event]);
+                await driver.insertMonitorChanges([change]);
+                await driver.insertMonitorChanges([change]);
+
+                const events = await driver.getResponseTimes({
+                    monitorId,
+                    since: new Date(timestamp.getTime() - 1000),
+                    limit: null,
+                });
+                const changes = await driver.getChangeTimeline({
+                    monitorId,
+                    limit: 10,
+                });
+
+                expect(events).toHaveLength(1);
+                expect(changes).toHaveLength(1);
+            });
+        });
+
         describe("aggregations", () => {
             it("computes the average latency over a time window", async () => {
                 const driver = getDriver();

--- a/packages/db/src/timeseries/timescale.ts
+++ b/packages/db/src/timeseries/timescale.ts
@@ -62,7 +62,7 @@ export class TimescaleDriver implements TimeSeriesDriver {
                 );
             }
             this.ownedClient = postgres(url, {
-                max: 20,
+                max: 10,
                 idle_timeout: 30,
             });
         }

--- a/packages/db/src/timeseries/timescale.ts
+++ b/packages/db/src/timeseries/timescale.ts
@@ -119,6 +119,10 @@ export class TimescaleDriver implements TimeSeriesDriver {
                     "CREATE INDEX IF NOT EXISTS monitor_events_monitor_location_time_idx ON monitor_events (monitor_id, location, timestamp DESC)",
                 );
 
+                await sql.unsafe(
+                    "CREATE UNIQUE INDEX IF NOT EXISTS monitor_events_id_timestamp_uidx ON monitor_events (id, timestamp)",
+                );
+
                 await sql.unsafe(`
 					CREATE TABLE IF NOT EXISTS monitor_changes (
 						id UUID NOT NULL,
@@ -135,6 +139,10 @@ export class TimescaleDriver implements TimeSeriesDriver {
 
                 await sql.unsafe(
                     "CREATE INDEX IF NOT EXISTS monitor_changes_monitor_time_idx ON monitor_changes (monitor_id, timestamp DESC)",
+                );
+
+                await sql.unsafe(
+                    "CREATE UNIQUE INDEX IF NOT EXISTS monitor_changes_id_timestamp_uidx ON monitor_changes (id, timestamp)",
                 );
 
                 await this.enableCompression(sql, {
@@ -212,7 +220,10 @@ export class TimescaleDriver implements TimeSeriesDriver {
             transfer: e.transfer ?? null,
         }));
 
-        await sql`INSERT INTO monitor_events ${sql(rows)}`;
+        await sql`
+            INSERT INTO monitor_events ${sql(rows)}
+            ON CONFLICT (id, timestamp) DO NOTHING
+        `;
     }
 
     async insertMonitorChanges(changes: MonitorChangeInsert[]) {
@@ -229,7 +240,10 @@ export class TimescaleDriver implements TimeSeriesDriver {
             location: c.location ?? null,
         }));
 
-        await sql`INSERT INTO monitor_changes ${sql(rows)}`;
+        await sql`
+            INSERT INTO monitor_changes ${sql(rows)}
+            ON CONFLICT (id, timestamp) DO NOTHING
+        `;
     }
 
     async getLatestEventForMonitor(


### PR DESCRIPTION
- Limit worker event request size, batch count, concurrency, and cache growth
- Make monitor event persistence transactional with post-commit notifications
- Aggregate status-page monitor health and optimize related database queries
- Reduce database connection pool sizes