### PR TITLE
fix(status-page): send rate limit timestamps as strings

### DIFF
--- a/apps/dash/src/status-page/lib/rate-limit.test.ts
+++ b/apps/dash/src/status-page/lib/rate-limit.test.ts
@@ -39,6 +39,7 @@ vi.mock("drizzle-orm", () => ({
     sql: vi.fn((strings, ...values) => ({ strings, values })),
 }));
 
+import { sql } from "drizzle-orm";
 import { checkRateLimit } from "./rate-limit";
 
 describe("checkRateLimit", () => {
@@ -72,6 +73,32 @@ describe("checkRateLimit", () => {
             remaining: 4,
             resetAt: expiresAt.getTime(),
         });
+    });
+
+    it("never passes raw Date values into sql fragments", async () => {
+        // Drizzle's postgres-js driver disables the driver's timestamp
+        // serializers, so a Date inside a raw `sql` template crashes the query
+        // with ERR_INVALID_ARG_TYPE instead of being sent as a timestamp.
+        mocks.returning.mockResolvedValue([
+            { attempts: 1, expiresAt: new Date("2026-08-09T12:15:00.000Z") },
+        ]);
+
+        await checkRateLimit("203.0.113.1:page-id");
+
+        const containsDate = (value: unknown): boolean => {
+            if (value instanceof Date) return true;
+            if (Array.isArray(value)) return value.some(containsDate);
+            if (value && typeof value === "object") {
+                return Object.values(value).some(containsDate);
+            }
+            return false;
+        };
+
+        const sqlCalls = vi
+            .mocked(sql)
+            .mock.results.map((result) => result.value);
+        expect(sqlCalls.length).toBeGreaterThan(0);
+        expect(sqlCalls.some(containsDate)).toBe(false);
     });
 
     it("rejects attempts over the configured maximum", async () => {

--- a/apps/dash/src/status-page/lib/rate-limit.ts
+++ b/apps/dash/src/status-page/lib/rate-limit.ts
@@ -23,6 +23,9 @@ export async function checkRateLimit(
         .update(`${namespace}:${identifier}`)
         .digest("hex");
 
+    const currentTimeSql = sql`${currentTime.toISOString()}::timestamp`;
+    const expiresAtSql = sql`${expiresAt.toISOString()}::timestamp`;
+
     await db
         .delete(rateLimitBucket)
         .where(lte(rateLimitBucket.expiresAt, currentTime));
@@ -34,11 +37,11 @@ export async function checkRateLimit(
             target: rateLimitBucket.key,
             set: {
                 attempts: sql<number>`case
-                    when ${rateLimitBucket.expiresAt} <= ${currentTime} then 1
+                    when ${rateLimitBucket.expiresAt} <= ${currentTimeSql} then 1
                     else ${rateLimitBucket.attempts} + 1
                 end`,
                 expiresAt: sql<Date>`case
-                    when ${rateLimitBucket.expiresAt} <= ${currentTime} then ${expiresAt}
+                    when ${rateLimitBucket.expiresAt} <= ${currentTimeSql} then ${expiresAtSql}
                     else ${rateLimitBucket.expiresAt}
                 end`,
             },


### PR DESCRIPTION
Password verification on private status pages always failed with a 500. `checkRateLimit` interpolated JS `Date` objects into the raw `sql` template used by the `onConflictDoUpdate` CASE expressions, which bypasses Drizzle's column mappers.

Because `drizzle-orm/postgres-js` replaces the driver's own timestamp serializers with a pass-through (types 1114/1184), those Dates reached the wire protocol unserialized and postgres.js threw:

    TypeError [ERR_INVALID_ARG_TYPE]: The "string" argument must be of type
    string or an instance of Buffer or ArrayBuffer. Received an instance of Date

The insert values were unaffected since they do run through the mapper, which is why only the raw fragments failed.

Pass the timestamps as ISO strings with an explicit `::timestamp` cast, matching the shape Drizzle's own mapper produces for `timestamp` columns, and add a regression test asserting no raw `Date` reaches a `sql` fragment.