### PR TITLE
feat(status-page): allow overriding monitor names per status page

### DIFF
--- a/apps/dash/src/app/(dashboard)/status-pages/[statusPageId]/structure/structure-editor.tsx
+++ b/apps/dash/src/app/(dashboard)/status-pages/[statusPageId]/structure/structure-editor.tsx
@@ -74,6 +74,11 @@ import {
     TooltipContent,
     TooltipTrigger,
 } from "@/components/ui/tooltip";
+import {
+    hasMonitorDisplayNameOverride,
+    normalizeMonitorDisplayName,
+    resolveMonitorDisplayName,
+} from "@/lib/status-page-monitor-name";
 import { cn } from "@/lib/utils";
 import { orpc } from "@/utils/orpc";
 
@@ -92,6 +97,7 @@ interface MonitorItem {
     name: string;
     type?: string;
     style: MonitorStyle;
+    displayName?: string | null; // Overrides `name` on this status page only
     description?: string | null;
 }
 
@@ -124,6 +130,7 @@ function toGroupItems(structure: any): GroupItem[] {
                 type: monitor.type,
                 style: monitor.style as MonitorStyle,
             }),
+            displayName: monitor.displayName,
             description: monitor.description,
         })),
     }));
@@ -470,6 +477,7 @@ function useStructureEditorState(statusPageId: string) {
                 monitors: g.monitors.map((m) => ({
                     id: m.id,
                     style: getMonitorStyle(m),
+                    displayName: normalizeMonitorDisplayName(m.displayName),
                     description: m.description,
                 })),
             })),
@@ -1086,8 +1094,13 @@ function MonitorRow({
                 {/* Icon + Name */}
                 <div className="flex min-w-0 flex-1 items-center gap-3">
                     <span className="truncate font-medium text-sm">
-                        {monitor.name}
+                        {resolveMonitorDisplayName(monitor)}
                     </span>
+                    {hasMonitorDisplayNameOverride(monitor) && (
+                        <span className="truncate text-muted-foreground text-xs">
+                            {monitor.name}
+                        </span>
+                    )}
                 </div>
 
                 {/* Actions */}
@@ -1164,12 +1177,33 @@ function MonitorConfigModal({
                         </Label>
                         <div className="rounded-2xl border border-border bg-card p-6">
                             <MonitorPreview
-                                name={monitor.name}
+                                name={resolveMonitorDisplayName(monitor)}
                                 style={selectedStyle}
                                 barStyle={barStyle}
                                 description={monitor.description}
                             />
                         </div>
+                    </div>
+
+                    {/* Display Name */}
+                    <div className="space-y-2">
+                        <Label className="font-normal text-muted-foreground text-xs">
+                            Display Name (optional)
+                        </Label>
+                        <Input
+                            value={monitor.displayName || ""}
+                            onChange={(e) =>
+                                onConfigChange?.({
+                                    displayName: e.target.value || null,
+                                })
+                            }
+                            placeholder={monitor.name}
+                        />
+                        <p className="text-muted-foreground text-xs">
+                            Shown instead of &quot;{monitor.name}&quot; on this
+                            status page only. Other status pages keep their own
+                            name.
+                        </p>
                     </div>
 
                     {/* Display Style Select */}

--- a/apps/dash/src/lib/status-page-monitor-name.test.ts
+++ b/apps/dash/src/lib/status-page-monitor-name.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+    hasMonitorDisplayNameOverride,
+    normalizeMonitorDisplayName,
+    resolveMonitorDisplayName,
+} from "./status-page-monitor-name";
+
+describe("resolveMonitorDisplayName", () => {
+    it("prefers the per-page override", () => {
+        expect(
+            resolveMonitorDisplayName({
+                name: "Checkout API",
+                displayName: "Payments",
+            }),
+        ).toBe("Payments");
+    });
+
+    it("trims the override", () => {
+        expect(
+            resolveMonitorDisplayName({
+                name: "Checkout API",
+                displayName: "  Payments  ",
+            }),
+        ).toBe("Payments");
+    });
+
+    it.each([
+        ["undefined", undefined],
+        ["null", null],
+        ["empty", ""],
+        ["whitespace only", "   "],
+    ])(
+        "falls back to the real name when the override is %s",
+        (_label, value) => {
+            expect(
+                resolveMonitorDisplayName({
+                    name: "Checkout API",
+                    displayName: value,
+                }),
+            ).toBe("Checkout API");
+        },
+    );
+});
+
+describe("hasMonitorDisplayNameOverride", () => {
+    it("reports an override that changes the label", () => {
+        expect(
+            hasMonitorDisplayNameOverride({
+                name: "Checkout API",
+                displayName: "Payments",
+            }),
+        ).toBe(true);
+    });
+
+    it("ignores an override equal to the real name", () => {
+        expect(
+            hasMonitorDisplayNameOverride({
+                name: "Checkout API",
+                displayName: "  Checkout API  ",
+            }),
+        ).toBe(false);
+    });
+
+    it("reports no override when none is set", () => {
+        expect(
+            hasMonitorDisplayNameOverride({
+                name: "Checkout API",
+                displayName: null,
+            }),
+        ).toBe(false);
+    });
+});
+
+describe("normalizeMonitorDisplayName", () => {
+    it("trims a real override", () => {
+        expect(normalizeMonitorDisplayName("  Payments ")).toBe("Payments");
+    });
+
+    it.each([
+        ["undefined", undefined],
+        ["null", null],
+        ["empty", ""],
+        ["whitespace only", "   "],
+    ])("stores %s as null", (_label, value) => {
+        expect(normalizeMonitorDisplayName(value)).toBeNull();
+    });
+});

--- a/apps/dash/src/lib/status-page-monitor-name.ts
+++ b/apps/dash/src/lib/status-page-monitor-name.ts
@@ -1,0 +1,43 @@
+interface MonitorNameInput {
+    name: string;
+    displayName?: string | null;
+}
+
+/**
+ * Resolve the name a monitor is shown under on a specific status page.
+ *
+ * A status page can override a monitor's name for its own audience, so the same
+ * monitor may appear as "Checkout API" on an internal page and as "Payments" on
+ * the public one. Blank or whitespace-only overrides fall back to the monitor's
+ * real name so a label is never empty.
+ *
+ * @param monitor - The monitor's real `name` plus the optional per-page override.
+ * @returns The trimmed override when one is set, otherwise the real name.
+ */
+export function resolveMonitorDisplayName(monitor: MonitorNameInput): string {
+    return monitor.displayName?.trim() || monitor.name;
+}
+
+/**
+ * Report whether a status page renames this monitor.
+ *
+ * @param monitor - The monitor's real `name` plus the optional per-page override.
+ * @returns `true` when the resolved name differs from the monitor's real name.
+ */
+export function hasMonitorDisplayNameOverride(
+    monitor: MonitorNameInput,
+): boolean {
+    return resolveMonitorDisplayName(monitor) !== monitor.name;
+}
+
+/**
+ * Normalize a display name override for storage.
+ *
+ * @param displayName - Raw user input from the status page structure editor.
+ * @returns The trimmed override, or `null` when it is empty or matches nothing.
+ */
+export function normalizeMonitorDisplayName(
+    displayName: string | null | undefined,
+): string | null {
+    return displayName?.trim() || null;
+}

--- a/apps/dash/src/status-page/lib/db-queries.ts
+++ b/apps/dash/src/status-page/lib/db-queries.ts
@@ -25,6 +25,10 @@ import {
 } from "drizzle-orm";
 import { cache } from "react";
 import {
+    normalizeMonitorDisplayName,
+    resolveMonitorDisplayName,
+} from "@/lib/status-page-monitor-name";
+import {
     getIncidentHistoryCutoff,
     type IncidentHistoryPeriod,
 } from "./incident-history";
@@ -64,6 +68,35 @@ async function withRetry<T>(
     }
     throw lastError;
 }
+
+const getStatusPageMonitorDisplayNames = cache(
+    async (statusPageId: string): Promise<Map<string, string>> => {
+        const rows = await db
+            .select({
+                monitorId: statusPageMonitor.monitorId,
+                displayName: statusPageMonitor.displayName,
+            })
+            .from(statusPageMonitor)
+            .where(
+                and(
+                    eq(statusPageMonitor.statusPageId, statusPageId),
+                    isNotNull(statusPageMonitor.displayName),
+                ),
+            );
+
+        return new Map(
+            rows.flatMap((row) => {
+                const displayName = normalizeMonitorDisplayName(
+                    row.displayName,
+                );
+
+                return displayName
+                    ? ([[row.monitorId, displayName]] as const)
+                    : [];
+            }),
+        );
+    },
+);
 
 async function getPublishedIncidentRecords(
     statusPageId: string,
@@ -131,7 +164,7 @@ async function getPublishedIncidentRecords(
         return [];
     }
 
-    return db.query.incidentStatusPage.findMany({
+    const records = await db.query.incidentStatusPage.findMany({
         columns: {
             incidentId: true,
             statusPageId: true,
@@ -181,6 +214,26 @@ async function getPublishedIncidentRecords(
             },
         },
     });
+
+    const displayNames = await getStatusPageMonitorDisplayNames(statusPageId);
+
+    if (displayNames.size === 0) {
+        return records;
+    }
+
+    return records.map((record) => ({
+        ...record,
+        incident: {
+            ...record.incident,
+            monitors: record.incident.monitors.map((item) => ({
+                ...item,
+                monitor: {
+                    ...item.monitor,
+                    name: displayNames.get(item.monitorId) ?? item.monitor.name,
+                },
+            })),
+        },
+    }));
 }
 
 function mapPublishedIncidentRecord(
@@ -270,6 +323,7 @@ async function getStatusPageMonitorRecords(statusPageId: string) {
             monitorId: true,
             groupId: true,
             style: true,
+            displayName: true,
             description: true,
             order: true,
         },
@@ -296,10 +350,21 @@ async function getStatusPageMonitorRecords(statusPageId: string) {
         orderBy: [asc(statusPageMonitor.order)],
     });
 
-    const monitorIds = records.map((record) => record.monitor.id);
+    const withDisplayNames = records.map((record) => ({
+        ...record,
+        monitor: {
+            ...record.monitor,
+            name: resolveMonitorDisplayName({
+                name: record.monitor.name,
+                displayName: record.displayName,
+            }),
+        },
+    }));
+
+    const monitorIds = withDisplayNames.map((record) => record.monitor.id);
 
     if (monitorIds.length === 0) {
-        return records;
+        return withDisplayNames;
     }
 
     const externalMonitorConfigs = await db
@@ -318,7 +383,7 @@ async function getStatusPageMonitorRecords(statusPageId: string) {
         externalMonitorConfigs.map((record) => [record.id, record.config]),
     );
 
-    return records.map((record) => ({
+    return withDisplayNames.map((record) => ({
         ...record,
         monitor: {
             ...record.monitor,

--- a/packages/api/src/routers/status-pages.ts
+++ b/packages/api/src/routers/status-pages.ts
@@ -385,6 +385,7 @@ export const statusPagesRouter = {
                         name: m.monitor.name,
                         type: m.monitor.type,
                         style: (m.style as "history" | "status") || "history",
+                        displayName: m.displayName,
                         description: m.description,
                     })),
                 })),
@@ -414,6 +415,7 @@ export const statusPagesRouter = {
                                 style: z
                                     .enum(["history", "status"])
                                     .default("history"),
+                                displayName: z.string().optional().nullable(),
                                 description: z.string().optional().nullable(),
                             }),
                         ),
@@ -496,6 +498,7 @@ export const statusPagesRouter = {
                                     monitorTypeById.get(m.id) === "instatus"
                                         ? "status"
                                         : m.style,
+                                displayName: m.displayName?.trim() || null,
                                 description: m.description || null,
                             })),
                         );

--- a/packages/db/src/migrations/0030_last_sauron.sql
+++ b/packages/db/src/migrations/0030_last_sauron.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "status_page_monitor" ADD COLUMN "display_name" text;

--- a/packages/db/src/migrations/meta/0030_snapshot.json
+++ b/packages/db/src/migrations/meta/0030_snapshot.json
@@ -1,0 +1,3890 @@
+{
+    "id": "da4f97d8-696a-4737-b447-a2e59341a5dd",
+    "prevId": "ffe50e19-1d61-4c78-a23d-d111b68632c5",
+    "version": "7",
+    "dialect": "postgresql",
+    "tables": {
+        "public.app_event_outbox": {
+            "name": "app_event_outbox",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "event_name": {
+                    "name": "event_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "organization_id": {
+                    "name": "organization_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "payload": {
+                    "name": "payload",
+                    "type": "jsonb",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "status": {
+                    "name": "status",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'pending'"
+                },
+                "attempts": {
+                    "name": "attempts",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": 0
+                },
+                "available_at": {
+                    "name": "available_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "locked_at": {
+                    "name": "locked_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "locked_by": {
+                    "name": "locked_by",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "processed_at": {
+                    "name": "processed_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "last_error": {
+                    "name": "last_error",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "app_event_outbox_ready_idx": {
+                    "name": "app_event_outbox_ready_idx",
+                    "columns": [
+                        {
+                            "expression": "status",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "available_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "app_event_outbox_locked_idx": {
+                    "name": "app_event_outbox_locked_idx",
+                    "columns": [
+                        {
+                            "expression": "status",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "locked_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "app_event_outbox_organization_idx": {
+                    "name": "app_event_outbox_organization_idx",
+                    "columns": [
+                        {
+                            "expression": "organization_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "app_event_outbox_created_idx": {
+                    "name": "app_event_outbox_created_idx",
+                    "columns": [
+                        {
+                            "expression": "created_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "app_event_outbox_organization_id_organization_id_fk": {
+                    "name": "app_event_outbox_organization_id_organization_id_fk",
+                    "tableFrom": "app_event_outbox",
+                    "tableTo": "organization",
+                    "columnsFrom": ["organization_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.account": {
+            "name": "account",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "account_id": {
+                    "name": "account_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "provider_id": {
+                    "name": "provider_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "access_token": {
+                    "name": "access_token",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "refresh_token": {
+                    "name": "refresh_token",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "id_token": {
+                    "name": "id_token",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "access_token_expires_at": {
+                    "name": "access_token_expires_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "refresh_token_expires_at": {
+                    "name": "refresh_token_expires_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "scope": {
+                    "name": "scope",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "password": {
+                    "name": "password",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {
+                "account_userId_idx": {
+                    "name": "account_userId_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "account_user_id_user_id_fk": {
+                    "name": "account_user_id_user_id_fk",
+                    "tableFrom": "account",
+                    "tableTo": "user",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.apikey": {
+            "name": "apikey",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "config_id": {
+                    "name": "config_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'default'"
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "start": {
+                    "name": "start",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "prefix": {
+                    "name": "prefix",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "key": {
+                    "name": "key",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "organization_id": {
+                    "name": "organization_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "refill_interval": {
+                    "name": "refill_interval",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "refill_amount": {
+                    "name": "refill_amount",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "last_refill_at": {
+                    "name": "last_refill_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "enabled": {
+                    "name": "enabled",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "default": true
+                },
+                "rate_limit_enabled": {
+                    "name": "rate_limit_enabled",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "default": true
+                },
+                "rate_limit_time_window": {
+                    "name": "rate_limit_time_window",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "default": 86400000
+                },
+                "rate_limit_max": {
+                    "name": "rate_limit_max",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "default": 10
+                },
+                "request_count": {
+                    "name": "request_count",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "default": 0
+                },
+                "remaining": {
+                    "name": "remaining",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "last_request": {
+                    "name": "last_request",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "expires_at": {
+                    "name": "expires_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "permissions": {
+                    "name": "permissions",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "metadata": {
+                    "name": "metadata",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "apikey_configId_idx": {
+                    "name": "apikey_configId_idx",
+                    "columns": [
+                        {
+                            "expression": "config_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "apikey_key_idx": {
+                    "name": "apikey_key_idx",
+                    "columns": [
+                        {
+                            "expression": "key",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "apikey_organizationId_idx": {
+                    "name": "apikey_organizationId_idx",
+                    "columns": [
+                        {
+                            "expression": "organization_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "apikey_organization_id_organization_id_fk": {
+                    "name": "apikey_organization_id_organization_id_fk",
+                    "tableFrom": "apikey",
+                    "tableTo": "organization",
+                    "columnsFrom": ["organization_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.invitation": {
+            "name": "invitation",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "organization_id": {
+                    "name": "organization_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "email": {
+                    "name": "email",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "role": {
+                    "name": "role",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "status": {
+                    "name": "status",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'pending'"
+                },
+                "expires_at": {
+                    "name": "expires_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "inviter_id": {
+                    "name": "inviter_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {
+                "invitation_organizationId_idx": {
+                    "name": "invitation_organizationId_idx",
+                    "columns": [
+                        {
+                            "expression": "organization_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "invitation_email_idx": {
+                    "name": "invitation_email_idx",
+                    "columns": [
+                        {
+                            "expression": "email",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "invitation_organization_id_organization_id_fk": {
+                    "name": "invitation_organization_id_organization_id_fk",
+                    "tableFrom": "invitation",
+                    "tableTo": "organization",
+                    "columnsFrom": ["organization_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "invitation_inviter_id_user_id_fk": {
+                    "name": "invitation_inviter_id_user_id_fk",
+                    "tableFrom": "invitation",
+                    "tableTo": "user",
+                    "columnsFrom": ["inviter_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.member": {
+            "name": "member",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "organization_id": {
+                    "name": "organization_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "role": {
+                    "name": "role",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'member'"
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {
+                "member_organizationId_idx": {
+                    "name": "member_organizationId_idx",
+                    "columns": [
+                        {
+                            "expression": "organization_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "member_userId_idx": {
+                    "name": "member_userId_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "member_organization_id_organization_id_fk": {
+                    "name": "member_organization_id_organization_id_fk",
+                    "tableFrom": "member",
+                    "tableTo": "organization",
+                    "columnsFrom": ["organization_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "member_user_id_user_id_fk": {
+                    "name": "member_user_id_user_id_fk",
+                    "tableFrom": "member",
+                    "tableTo": "user",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.organization": {
+            "name": "organization",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "slug": {
+                    "name": "slug",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "logo": {
+                    "name": "logo",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "active_monitor_limit": {
+                    "name": "active_monitor_limit",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "regions_per_monitor_limit": {
+                    "name": "regions_per_monitor_limit",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "metadata": {
+                    "name": "metadata",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "organization_slug_unique": {
+                    "name": "organization_slug_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["slug"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.organization_oidc_provider": {
+            "name": "organization_oidc_provider",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "organization_id": {
+                    "name": "organization_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "enabled": {
+                    "name": "enabled",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "issuer": {
+                    "name": "issuer",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "discovery_url": {
+                    "name": "discovery_url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "client_id": {
+                    "name": "client_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "client_secret": {
+                    "name": "client_secret",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "domains": {
+                    "name": "domains",
+                    "type": "json",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "scopes": {
+                    "name": "scopes",
+                    "type": "json",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "organization_oidc_provider_organization_idx": {
+                    "name": "organization_oidc_provider_organization_idx",
+                    "columns": [
+                        {
+                            "expression": "organization_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "organization_oidc_provider_enabled_idx": {
+                    "name": "organization_oidc_provider_enabled_idx",
+                    "columns": [
+                        {
+                            "expression": "enabled",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "organization_oidc_provider_organization_id_organization_id_fk": {
+                    "name": "organization_oidc_provider_organization_id_organization_id_fk",
+                    "tableFrom": "organization_oidc_provider",
+                    "tableTo": "organization",
+                    "columnsFrom": ["organization_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.session": {
+            "name": "session",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "expires_at": {
+                    "name": "expires_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "token": {
+                    "name": "token",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "ip_address": {
+                    "name": "ip_address",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "user_agent": {
+                    "name": "user_agent",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "impersonated_by": {
+                    "name": "impersonated_by",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "active_organization_id": {
+                    "name": "active_organization_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "session_userId_idx": {
+                    "name": "session_userId_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "session_user_id_user_id_fk": {
+                    "name": "session_user_id_user_id_fk",
+                    "tableFrom": "session",
+                    "tableTo": "user",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "session_token_unique": {
+                    "name": "session_token_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["token"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.twoFactor": {
+            "name": "twoFactor",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "secret": {
+                    "name": "secret",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "backup_codes": {
+                    "name": "backup_codes",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "verified": {
+                    "name": "verified",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "default": true
+                }
+            },
+            "indexes": {
+                "twoFactor_userId_idx": {
+                    "name": "twoFactor_userId_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "twoFactor_user_id_user_id_fk": {
+                    "name": "twoFactor_user_id_user_id_fk",
+                    "tableFrom": "twoFactor",
+                    "tableTo": "user",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.user": {
+            "name": "user",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "email": {
+                    "name": "email",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "email_verified": {
+                    "name": "email_verified",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "image": {
+                    "name": "image",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "role": {
+                    "name": "role",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "banned": {
+                    "name": "banned",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "default": false
+                },
+                "ban_reason": {
+                    "name": "ban_reason",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "ban_expires": {
+                    "name": "ban_expires",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "two_factor_enabled": {
+                    "name": "two_factor_enabled",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "default": false
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "user_email_unique": {
+                    "name": "user_email_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["email"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.verification": {
+            "name": "verification",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "identifier": {
+                    "name": "identifier",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "value": {
+                    "name": "value",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "expires_at": {
+                    "name": "expires_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "verification_identifier_idx": {
+                    "name": "verification_identifier_idx",
+                    "columns": [
+                        {
+                            "expression": "identifier",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.configuration": {
+            "name": "configuration",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "key": {
+                    "name": "key",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "value": {
+                    "name": "value",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "configuration_key_unique": {
+                    "name": "configuration_key_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["key"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.incident": {
+            "name": "incident",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "organization_id": {
+                    "name": "organization_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title": {
+                    "name": "title",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "description": {
+                    "name": "description",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "status": {
+                    "name": "status",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "severity": {
+                    "name": "severity",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'major'"
+                },
+                "type": {
+                    "name": "type",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'manual'"
+                },
+                "acknowledged_at": {
+                    "name": "acknowledged_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "acknowledged_by": {
+                    "name": "acknowledged_by",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "started_at": {
+                    "name": "started_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "planned_end_at": {
+                    "name": "planned_end_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "ended_at": {
+                    "name": "ended_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "resolved_at": {
+                    "name": "resolved_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "external_id": {
+                    "name": "external_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "external_source": {
+                    "name": "external_source",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "incident_organization_idx": {
+                    "name": "incident_organization_idx",
+                    "columns": [
+                        {
+                            "expression": "organization_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "incident_status_idx": {
+                    "name": "incident_status_idx",
+                    "columns": [
+                        {
+                            "expression": "status",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "incident_started_at_idx": {
+                    "name": "incident_started_at_idx",
+                    "columns": [
+                        {
+                            "expression": "started_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "incident_ended_at_idx": {
+                    "name": "incident_ended_at_idx",
+                    "columns": [
+                        {
+                            "expression": "ended_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "incident_external_unique_idx": {
+                    "name": "incident_external_unique_idx",
+                    "columns": [
+                        {
+                            "expression": "organization_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "external_source",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "external_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": true,
+                    "where": "\"incident\".\"external_source\" IS NOT NULL AND \"incident\".\"external_id\" IS NOT NULL",
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "incident_organization_id_organization_id_fk": {
+                    "name": "incident_organization_id_organization_id_fk",
+                    "tableFrom": "incident",
+                    "tableTo": "organization",
+                    "columnsFrom": ["organization_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "incident_acknowledged_by_user_id_fk": {
+                    "name": "incident_acknowledged_by_user_id_fk",
+                    "tableFrom": "incident",
+                    "tableTo": "user",
+                    "columnsFrom": ["acknowledged_by"],
+                    "columnsTo": ["id"],
+                    "onDelete": "no action",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.incident_activity": {
+            "name": "incident_activity",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "incident_id": {
+                    "name": "incident_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "message": {
+                    "name": "message",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "type": {
+                    "name": "type",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'comment'"
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "incident_activity_incidentId_idx": {
+                    "name": "incident_activity_incidentId_idx",
+                    "columns": [
+                        {
+                            "expression": "incident_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "incident_activity_incident_id_incident_id_fk": {
+                    "name": "incident_activity_incident_id_incident_id_fk",
+                    "tableFrom": "incident_activity",
+                    "tableTo": "incident",
+                    "columnsFrom": ["incident_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "incident_activity_user_id_user_id_fk": {
+                    "name": "incident_activity_user_id_user_id_fk",
+                    "tableFrom": "incident_activity",
+                    "tableTo": "user",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "no action",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.incident_monitor": {
+            "name": "incident_monitor",
+            "schema": "",
+            "columns": {
+                "incident_id": {
+                    "name": "incident_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "monitor_id": {
+                    "name": "monitor_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {
+                "incident_monitor_incident_idx": {
+                    "name": "incident_monitor_incident_idx",
+                    "columns": [
+                        {
+                            "expression": "incident_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "incident_monitor_monitor_idx": {
+                    "name": "incident_monitor_monitor_idx",
+                    "columns": [
+                        {
+                            "expression": "monitor_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "incident_monitor_incident_id_incident_id_fk": {
+                    "name": "incident_monitor_incident_id_incident_id_fk",
+                    "tableFrom": "incident_monitor",
+                    "tableTo": "incident",
+                    "columnsFrom": ["incident_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "incident_monitor_monitor_id_monitor_id_fk": {
+                    "name": "incident_monitor_monitor_id_monitor_id_fk",
+                    "tableFrom": "incident_monitor",
+                    "tableTo": "monitor",
+                    "columnsFrom": ["monitor_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {
+                "incident_monitor_incident_id_monitor_id_pk": {
+                    "name": "incident_monitor_incident_id_monitor_id_pk",
+                    "columns": ["incident_id", "monitor_id"]
+                }
+            },
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.incident_status_page": {
+            "name": "incident_status_page",
+            "schema": "",
+            "columns": {
+                "incident_id": {
+                    "name": "incident_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "status_page_id": {
+                    "name": "status_page_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {
+                "incident_status_page_incident_idx": {
+                    "name": "incident_status_page_incident_idx",
+                    "columns": [
+                        {
+                            "expression": "incident_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "incident_status_page_status_page_idx": {
+                    "name": "incident_status_page_status_page_idx",
+                    "columns": [
+                        {
+                            "expression": "status_page_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "incident_status_page_incident_id_incident_id_fk": {
+                    "name": "incident_status_page_incident_id_incident_id_fk",
+                    "tableFrom": "incident_status_page",
+                    "tableTo": "incident",
+                    "columnsFrom": ["incident_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "incident_status_page_status_page_id_status_page_id_fk": {
+                    "name": "incident_status_page_status_page_id_status_page_id_fk",
+                    "tableFrom": "incident_status_page",
+                    "tableTo": "status_page",
+                    "columnsFrom": ["status_page_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {
+                "incident_status_page_incident_id_status_page_id_pk": {
+                    "name": "incident_status_page_incident_id_status_page_id_pk",
+                    "columns": ["incident_id", "status_page_id"]
+                }
+            },
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.integration_config": {
+            "name": "integration_config",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "organization_id": {
+                    "name": "organization_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "type": {
+                    "name": "type",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "config": {
+                    "name": "config",
+                    "type": "json",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "active": {
+                    "name": "active",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": true
+                },
+                "is_default": {
+                    "name": "is_default",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "enabled_events": {
+                    "name": "enabled_events",
+                    "type": "json",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "integration_config_org_idx": {
+                    "name": "integration_config_org_idx",
+                    "columns": [
+                        {
+                            "expression": "organization_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "integration_config_type_idx": {
+                    "name": "integration_config_type_idx",
+                    "columns": [
+                        {
+                            "expression": "type",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "integration_config_organization_id_organization_id_fk": {
+                    "name": "integration_config_organization_id_organization_id_fk",
+                    "tableFrom": "integration_config",
+                    "tableTo": "organization",
+                    "columnsFrom": ["organization_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.monitor_notification": {
+            "name": "monitor_notification",
+            "schema": "",
+            "columns": {
+                "monitor_id": {
+                    "name": "monitor_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "integration_config_id": {
+                    "name": "integration_config_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "monitor_notification_monitor_idx": {
+                    "name": "monitor_notification_monitor_idx",
+                    "columns": [
+                        {
+                            "expression": "monitor_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "monitor_notification_config_idx": {
+                    "name": "monitor_notification_config_idx",
+                    "columns": [
+                        {
+                            "expression": "integration_config_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "monitor_notification_monitor_id_monitor_id_fk": {
+                    "name": "monitor_notification_monitor_id_monitor_id_fk",
+                    "tableFrom": "monitor_notification",
+                    "tableTo": "monitor",
+                    "columnsFrom": ["monitor_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "monitor_notification_integration_config_id_integration_config_id_fk": {
+                    "name": "monitor_notification_integration_config_id_integration_config_id_fk",
+                    "tableFrom": "monitor_notification",
+                    "tableTo": "integration_config",
+                    "columnsFrom": ["integration_config_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {
+                "monitor_notification_monitor_id_integration_config_id_pk": {
+                    "name": "monitor_notification_monitor_id_integration_config_id_pk",
+                    "columns": ["monitor_id", "integration_config_id"]
+                }
+            },
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.maintenance": {
+            "name": "maintenance",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "organization_id": {
+                    "name": "organization_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title": {
+                    "name": "title",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "description": {
+                    "name": "description",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "start_at": {
+                    "name": "start_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "end_at": {
+                    "name": "end_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "status": {
+                    "name": "status",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "maintenance_organizationId_idx": {
+                    "name": "maintenance_organizationId_idx",
+                    "columns": [
+                        {
+                            "expression": "organization_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "maintenance_status_idx": {
+                    "name": "maintenance_status_idx",
+                    "columns": [
+                        {
+                            "expression": "status",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "maintenance_startAt_idx": {
+                    "name": "maintenance_startAt_idx",
+                    "columns": [
+                        {
+                            "expression": "start_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "maintenance_endAt_idx": {
+                    "name": "maintenance_endAt_idx",
+                    "columns": [
+                        {
+                            "expression": "end_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "maintenance_organization_id_organization_id_fk": {
+                    "name": "maintenance_organization_id_organization_id_fk",
+                    "tableFrom": "maintenance",
+                    "tableTo": "organization",
+                    "columnsFrom": ["organization_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.maintenance_monitor": {
+            "name": "maintenance_monitor",
+            "schema": "",
+            "columns": {
+                "maintenance_id": {
+                    "name": "maintenance_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "monitor_id": {
+                    "name": "monitor_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {
+                "maintenance_monitor_maintenanceId_idx": {
+                    "name": "maintenance_monitor_maintenanceId_idx",
+                    "columns": [
+                        {
+                            "expression": "maintenance_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "maintenance_monitor_monitorId_idx": {
+                    "name": "maintenance_monitor_monitorId_idx",
+                    "columns": [
+                        {
+                            "expression": "monitor_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "maintenance_monitor_maintenance_id_maintenance_id_fk": {
+                    "name": "maintenance_monitor_maintenance_id_maintenance_id_fk",
+                    "tableFrom": "maintenance_monitor",
+                    "tableTo": "maintenance",
+                    "columnsFrom": ["maintenance_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "maintenance_monitor_monitor_id_monitor_id_fk": {
+                    "name": "maintenance_monitor_monitor_id_monitor_id_fk",
+                    "tableFrom": "maintenance_monitor",
+                    "tableTo": "monitor",
+                    "columnsFrom": ["monitor_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.maintenance_status_page": {
+            "name": "maintenance_status_page",
+            "schema": "",
+            "columns": {
+                "maintenance_id": {
+                    "name": "maintenance_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "status_page_id": {
+                    "name": "status_page_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {
+                "maintenance_status_page_maintenanceId_idx": {
+                    "name": "maintenance_status_page_maintenanceId_idx",
+                    "columns": [
+                        {
+                            "expression": "maintenance_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "maintenance_status_page_statusPageId_idx": {
+                    "name": "maintenance_status_page_statusPageId_idx",
+                    "columns": [
+                        {
+                            "expression": "status_page_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "maintenance_status_page_maintenance_id_maintenance_id_fk": {
+                    "name": "maintenance_status_page_maintenance_id_maintenance_id_fk",
+                    "tableFrom": "maintenance_status_page",
+                    "tableTo": "maintenance",
+                    "columnsFrom": ["maintenance_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "maintenance_status_page_status_page_id_status_page_id_fk": {
+                    "name": "maintenance_status_page_status_page_id_status_page_id_fk",
+                    "tableFrom": "maintenance_status_page",
+                    "tableTo": "status_page",
+                    "columnsFrom": ["status_page_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.maintenance_update": {
+            "name": "maintenance_update",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "maintenance_id": {
+                    "name": "maintenance_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "message": {
+                    "name": "message",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "status": {
+                    "name": "status",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "maintenance_update_maintenanceId_idx": {
+                    "name": "maintenance_update_maintenanceId_idx",
+                    "columns": [
+                        {
+                            "expression": "maintenance_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "maintenance_update_maintenance_id_maintenance_id_fk": {
+                    "name": "maintenance_update_maintenance_id_maintenance_id_fk",
+                    "tableFrom": "maintenance_update",
+                    "tableTo": "maintenance",
+                    "columnsFrom": ["maintenance_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.monitor": {
+            "name": "monitor",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "organization_id": {
+                    "name": "organization_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "group_id": {
+                    "name": "group_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "type": {
+                    "name": "type",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "active": {
+                    "name": "active",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": true
+                },
+                "pause_reason": {
+                    "name": "pause_reason",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "interval": {
+                    "name": "interval",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": 60
+                },
+                "timeout": {
+                    "name": "timeout",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": 48
+                },
+                "retries": {
+                    "name": "retries",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": 2
+                },
+                "retry_interval": {
+                    "name": "retry_interval",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": 20
+                },
+                "incident_pending_duration": {
+                    "name": "incident_pending_duration",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": 0
+                },
+                "incident_recovery_duration": {
+                    "name": "incident_recovery_duration",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": 0
+                },
+                "publish_incident_to_status_page": {
+                    "name": "publish_incident_to_status_page",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "locations": {
+                    "name": "locations",
+                    "type": "json",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "worker_ids": {
+                    "name": "worker_ids",
+                    "type": "json",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "config": {
+                    "name": "config",
+                    "type": "json",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "success_statuses": {
+                    "name": "success_statuses",
+                    "type": "json",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "monitor_organization_created_idx": {
+                    "name": "monitor_organization_created_idx",
+                    "columns": [
+                        {
+                            "expression": "organization_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "created_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        },
+                        {
+                            "expression": "id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "monitor_active_idx": {
+                    "name": "monitor_active_idx",
+                    "columns": [
+                        {
+                            "expression": "active",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "monitor_group_idx": {
+                    "name": "monitor_group_idx",
+                    "columns": [
+                        {
+                            "expression": "group_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "monitor_organization_id_organization_id_fk": {
+                    "name": "monitor_organization_id_organization_id_fk",
+                    "tableFrom": "monitor",
+                    "tableTo": "organization",
+                    "columnsFrom": ["organization_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "monitor_group_id_monitor_group_id_fk": {
+                    "name": "monitor_group_id_monitor_group_id_fk",
+                    "tableFrom": "monitor",
+                    "tableTo": "monitor_group",
+                    "columnsFrom": ["group_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.monitor_group": {
+            "name": "monitor_group",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "organization_id": {
+                    "name": "organization_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "parent_id": {
+                    "name": "parent_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "monitor_group_organization_idx": {
+                    "name": "monitor_group_organization_idx",
+                    "columns": [
+                        {
+                            "expression": "organization_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "monitor_group_parent_idx": {
+                    "name": "monitor_group_parent_idx",
+                    "columns": [
+                        {
+                            "expression": "parent_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "monitor_group_organization_id_organization_id_fk": {
+                    "name": "monitor_group_organization_id_organization_id_fk",
+                    "tableFrom": "monitor_group",
+                    "tableTo": "organization",
+                    "columnsFrom": ["organization_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "monitor_group_parent_id_monitor_group_id_fk": {
+                    "name": "monitor_group_parent_id_monitor_group_id_fk",
+                    "tableFrom": "monitor_group",
+                    "tableTo": "monitor_group",
+                    "columnsFrom": ["parent_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.rate_limit_bucket": {
+            "name": "rate_limit_bucket",
+            "schema": "",
+            "columns": {
+                "key": {
+                    "name": "key",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "attempts": {
+                    "name": "attempts",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": 1
+                },
+                "expires_at": {
+                    "name": "expires_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {
+                "rate_limit_bucket_expires_at_idx": {
+                    "name": "rate_limit_bucket_expires_at_idx",
+                    "columns": [
+                        {
+                            "expression": "expires_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.ssl_certificate_notification": {
+            "name": "ssl_certificate_notification",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "monitor_id": {
+                    "name": "monitor_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "domain": {
+                    "name": "domain",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "last_notified_at": {
+                    "name": "last_notified_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "days_until_expiry_at_notification": {
+                    "name": "days_until_expiry_at_notification",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "ssl_cert_notification_monitor_idx": {
+                    "name": "ssl_cert_notification_monitor_idx",
+                    "columns": [
+                        {
+                            "expression": "monitor_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "ssl_cert_notification_domain_idx": {
+                    "name": "ssl_cert_notification_domain_idx",
+                    "columns": [
+                        {
+                            "expression": "domain",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "ssl_certificate_notification_monitor_id_monitor_id_fk": {
+                    "name": "ssl_certificate_notification_monitor_id_monitor_id_fk",
+                    "tableFrom": "ssl_certificate_notification",
+                    "tableTo": "monitor",
+                    "columnsFrom": ["monitor_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.status_page": {
+            "name": "status_page",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "organization_id": {
+                    "name": "organization_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "slug": {
+                    "name": "slug",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "domain": {
+                    "name": "domain",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "description": {
+                    "name": "description",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "public": {
+                    "name": "public",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": true
+                },
+                "password": {
+                    "name": "password",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "design": {
+                    "name": "design",
+                    "type": "json",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "status_page_organization_idx": {
+                    "name": "status_page_organization_idx",
+                    "columns": [
+                        {
+                            "expression": "organization_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "status_page_slug_idx": {
+                    "name": "status_page_slug_idx",
+                    "columns": [
+                        {
+                            "expression": "slug",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "status_page_domain_idx": {
+                    "name": "status_page_domain_idx",
+                    "columns": [
+                        {
+                            "expression": "domain",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "status_page_organization_id_organization_id_fk": {
+                    "name": "status_page_organization_id_organization_id_fk",
+                    "tableFrom": "status_page",
+                    "tableTo": "organization",
+                    "columnsFrom": ["organization_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "status_page_slug_unique": {
+                    "name": "status_page_slug_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["slug"]
+                },
+                "status_page_domain_unique": {
+                    "name": "status_page_domain_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["domain"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.status_page_group": {
+            "name": "status_page_group",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "status_page_id": {
+                    "name": "status_page_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "order": {
+                    "name": "order",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": 0
+                },
+                "collapsible": {
+                    "name": "collapsible",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": true
+                },
+                "default_collapsed": {
+                    "name": "default_collapsed",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                }
+            },
+            "indexes": {
+                "status_page_group_pageId_idx": {
+                    "name": "status_page_group_pageId_idx",
+                    "columns": [
+                        {
+                            "expression": "status_page_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "status_page_group_status_page_id_status_page_id_fk": {
+                    "name": "status_page_group_status_page_id_status_page_id_fk",
+                    "tableFrom": "status_page_group",
+                    "tableTo": "status_page",
+                    "columnsFrom": ["status_page_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.status_page_monitor": {
+            "name": "status_page_monitor",
+            "schema": "",
+            "columns": {
+                "status_page_id": {
+                    "name": "status_page_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "monitor_id": {
+                    "name": "monitor_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "group_id": {
+                    "name": "group_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "style": {
+                    "name": "style",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'history'"
+                },
+                "display_name": {
+                    "name": "display_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "description": {
+                    "name": "description",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "order": {
+                    "name": "order",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": 0
+                }
+            },
+            "indexes": {
+                "status_page_monitor_pageId_idx": {
+                    "name": "status_page_monitor_pageId_idx",
+                    "columns": [
+                        {
+                            "expression": "status_page_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "status_page_monitor_monitorId_idx": {
+                    "name": "status_page_monitor_monitorId_idx",
+                    "columns": [
+                        {
+                            "expression": "monitor_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "status_page_monitor_status_page_id_status_page_id_fk": {
+                    "name": "status_page_monitor_status_page_id_status_page_id_fk",
+                    "tableFrom": "status_page_monitor",
+                    "tableTo": "status_page",
+                    "columnsFrom": ["status_page_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "status_page_monitor_monitor_id_monitor_id_fk": {
+                    "name": "status_page_monitor_monitor_id_monitor_id_fk",
+                    "tableFrom": "status_page_monitor",
+                    "tableTo": "monitor",
+                    "columnsFrom": ["monitor_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "status_page_monitor_group_id_status_page_group_id_fk": {
+                    "name": "status_page_monitor_group_id_status_page_group_id_fk",
+                    "tableFrom": "status_page_monitor",
+                    "tableTo": "status_page_group",
+                    "columnsFrom": ["group_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.status_page_email_subscribers": {
+            "name": "status_page_email_subscribers",
+            "schema": "",
+            "columns": {
+                "email": {
+                    "name": "email",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "slack_webhook_url": {
+                    "name": "slack_webhook_url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "discord_webhook_url": {
+                    "name": "discord_webhook_url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "status_page_id": {
+                    "name": "status_page_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "status_page_email_subscribers_page_id_idx": {
+                    "name": "status_page_email_subscribers_page_id_idx",
+                    "columns": [
+                        {
+                            "expression": "status_page_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "status_page_email_subscribers_status_page_id_status_page_id_fk": {
+                    "name": "status_page_email_subscribers_status_page_id_status_page_id_fk",
+                    "tableFrom": "status_page_email_subscribers",
+                    "tableTo": "status_page",
+                    "columnsFrom": ["status_page_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {
+                "status_page_email_subscribers_status_page_id_email_pk": {
+                    "name": "status_page_email_subscribers_status_page_id_email_pk",
+                    "columns": ["status_page_id", "email"]
+                }
+            },
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.status_page_report": {
+            "name": "status_page_report",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "status_page_id": {
+                    "name": "status_page_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "title": {
+                    "name": "title",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "status": {
+                    "name": "status",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "severity": {
+                    "name": "severity",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'major'"
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "resolved_at": {
+                    "name": "resolved_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "status_page_report_pageId_idx": {
+                    "name": "status_page_report_pageId_idx",
+                    "columns": [
+                        {
+                            "expression": "status_page_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "status_page_report_status_idx": {
+                    "name": "status_page_report_status_idx",
+                    "columns": [
+                        {
+                            "expression": "status",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "status_page_report_status_page_id_status_page_id_fk": {
+                    "name": "status_page_report_status_page_id_status_page_id_fk",
+                    "tableFrom": "status_page_report",
+                    "tableTo": "status_page",
+                    "columnsFrom": ["status_page_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.status_page_report_monitor": {
+            "name": "status_page_report_monitor",
+            "schema": "",
+            "columns": {
+                "report_id": {
+                    "name": "report_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "monitor_id": {
+                    "name": "monitor_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "status": {
+                    "name": "status",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "status_page_report_monitor_reportId_idx": {
+                    "name": "status_page_report_monitor_reportId_idx",
+                    "columns": [
+                        {
+                            "expression": "report_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "status_page_report_monitor_monitorId_idx": {
+                    "name": "status_page_report_monitor_monitorId_idx",
+                    "columns": [
+                        {
+                            "expression": "monitor_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "status_page_report_monitor_report_id_status_page_report_id_fk": {
+                    "name": "status_page_report_monitor_report_id_status_page_report_id_fk",
+                    "tableFrom": "status_page_report_monitor",
+                    "tableTo": "status_page_report",
+                    "columnsFrom": ["report_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "status_page_report_monitor_monitor_id_monitor_id_fk": {
+                    "name": "status_page_report_monitor_monitor_id_monitor_id_fk",
+                    "tableFrom": "status_page_report_monitor",
+                    "tableTo": "monitor",
+                    "columnsFrom": ["monitor_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.status_page_report_update": {
+            "name": "status_page_report_update",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "report_id": {
+                    "name": "report_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "message": {
+                    "name": "message",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "status": {
+                    "name": "status",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "status_page_report_update_reportId_idx": {
+                    "name": "status_page_report_update_reportId_idx",
+                    "columns": [
+                        {
+                            "expression": "report_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "status_page_report_update_report_id_status_page_report_id_fk": {
+                    "name": "status_page_report_update_report_id_status_page_report_id_fk",
+                    "tableFrom": "status_page_report_update",
+                    "tableTo": "status_page_report",
+                    "columnsFrom": ["report_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "status_page_report_update_user_id_user_id_fk": {
+                    "name": "status_page_report_update_user_id_user_id_fk",
+                    "tableFrom": "status_page_report_update",
+                    "tableTo": "user",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "no action",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.monitor_tag": {
+            "name": "monitor_tag",
+            "schema": "",
+            "columns": {
+                "monitor_id": {
+                    "name": "monitor_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "tag_id": {
+                    "name": "tag_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "monitor_tag_monitor_idx": {
+                    "name": "monitor_tag_monitor_idx",
+                    "columns": [
+                        {
+                            "expression": "monitor_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "monitor_tag_tag_idx": {
+                    "name": "monitor_tag_tag_idx",
+                    "columns": [
+                        {
+                            "expression": "tag_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "monitor_tag_monitor_id_monitor_id_fk": {
+                    "name": "monitor_tag_monitor_id_monitor_id_fk",
+                    "tableFrom": "monitor_tag",
+                    "tableTo": "monitor",
+                    "columnsFrom": ["monitor_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "monitor_tag_tag_id_tag_id_fk": {
+                    "name": "monitor_tag_tag_id_tag_id_fk",
+                    "tableFrom": "monitor_tag",
+                    "tableTo": "tag",
+                    "columnsFrom": ["tag_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {
+                "monitor_tag_monitor_id_tag_id_pk": {
+                    "name": "monitor_tag_monitor_id_tag_id_pk",
+                    "columns": ["monitor_id", "tag_id"]
+                }
+            },
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.tag": {
+            "name": "tag",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "organization_id": {
+                    "name": "organization_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "color": {
+                    "name": "color",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'#3b82f6'"
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "tag_organization_idx": {
+                    "name": "tag_organization_idx",
+                    "columns": [
+                        {
+                            "expression": "organization_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "tag_name_idx": {
+                    "name": "tag_name_idx",
+                    "columns": [
+                        {
+                            "expression": "name",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "tag_organization_id_organization_id_fk": {
+                    "name": "tag_organization_id_organization_id_fk",
+                    "tableFrom": "tag",
+                    "tableTo": "organization",
+                    "columnsFrom": ["organization_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.worker": {
+            "name": "worker",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "location": {
+                    "name": "location",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "active": {
+                    "name": "active",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": true
+                },
+                "last_heartbeat": {
+                    "name": "last_heartbeat",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "version": {
+                    "name": "version",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "worker_location_idx": {
+                    "name": "worker_location_idx",
+                    "columns": [
+                        {
+                            "expression": "location",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "worker_active_idx": {
+                    "name": "worker_active_idx",
+                    "columns": [
+                        {
+                            "expression": "active",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.worker_api_key": {
+            "name": "worker_api_key",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "key_hash": {
+                    "name": "key_hash",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "key_hint": {
+                    "name": "key_hint",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "worker_id": {
+                    "name": "worker_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "last_used_at": {
+                    "name": "last_used_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "worker_api_key_hash_idx": {
+                    "name": "worker_api_key_hash_idx",
+                    "columns": [
+                        {
+                            "expression": "key_hash",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "worker_api_key_worker_id_idx": {
+                    "name": "worker_api_key_worker_id_idx",
+                    "columns": [
+                        {
+                            "expression": "worker_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "worker_api_key_worker_id_worker_id_fk": {
+                    "name": "worker_api_key_worker_id_worker_id_fk",
+                    "tableFrom": "worker_api_key",
+                    "tableTo": "worker",
+                    "columnsFrom": ["worker_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "worker_api_key_key_hash_unique": {
+                    "name": "worker_api_key_key_hash_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["key_hash"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        }
+    },
+    "enums": {},
+    "schemas": {},
+    "sequences": {},
+    "roles": {},
+    "policies": {},
+    "views": {},
+    "_meta": {
+        "columns": {},
+        "schemas": {},
+        "tables": {}
+    }
+}

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -211,6 +211,13 @@
             "when": 1786256776454,
             "tag": "0029_wandering_nova",
             "breakpoints": true
+        },
+        {
+            "idx": 30,
+            "version": "7",
+            "when": 1787749257189,
+            "tag": "0030_last_sauron",
+            "breakpoints": true
         }
     ]
 }

--- a/packages/db/src/schema/status-pages.ts
+++ b/packages/db/src/schema/status-pages.ts
@@ -66,6 +66,7 @@ export const statusPageMonitor = pgTable(
             onDelete: "set null",
         }),
         style: text("style").default("history").notNull(), // 'history' | 'status'
+        displayName: text("display_name"), // Optional per-page override for the monitor name
         description: text("description"), // Optional description shown in info tooltip
         order: integer("order").default(0).notNull(),
     },


### PR DESCRIPTION
The same monitor often needs a different label depending on the audience: an internal page may want "Checkout API (prod-eu-1)" while the public page should only ever show "Payments". Until now the monitor's own name was the only name available, so renaming it changed every status page at once.

Adds an optional `display_name` to `status_page_monitor`. It is editable in the structure editor's monitor dialog, falls back to the monitor's real name when blank, and is scoped to a single status page.

The override is resolved in the status page queries, so every consumer *all four themes, incident and maintenance views, RSS/Atom feeds, OG images and status badges — picks it up without further changes. Affected monitors on incidents use the same names as the monitor list, so a page never leaks the underlying monitor name.

The structure editor keeps showing the real name next to the override so monitors stay identifiable while editing.