### PR TITLE
Build Docker images for amd64 and arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,6 +185,7 @@ jobs:
         with:
           context: .
           file: ${{ steps.prep.outputs.app_dir }}/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,6 +172,8 @@ jobs:
 
       - name: Setup Blacksmith Builder
         uses: useblacksmith/setup-docker-builder@v1
+        with:
+          platforms: linux/amd64,linux/arm64
 
       - name: Docker Login to GHCR
         uses: docker/login-action@v3


### PR DESCRIPTION
### What

Build the published Docker images for both `linux/amd64` and `linux/arm64`.

### Why

The current release workflow only publishes an image for the build platform. This prevents the images from being pulled on ARM64 hosts, for example Hetzner ARM servers running Coolify.

QEMU is already configured in the workflow, so this just adds the target platforms to the Docker build.

### Change

Added:

platforms: linux/amd64,linux/arm64

No other changes to the release workflow.