### PR TITLE
fix(app-review): address accessibility, status-page, audit, and worker findings

### DIFF
--- a/apps/dash/src/components/ui/data-pagination.tsx
+++ b/apps/dash/src/components/ui/data-pagination.tsx
@@ -36,6 +36,7 @@ export function DataPagination({
                         <Button
                             variant="ghost"
                             size="icon"
+                            aria-label="Previous page"
                             disabled={page === 1}
                             onClick={() => setPage(page - 1)}
                         >
@@ -83,6 +84,7 @@ export function DataPagination({
                         <Button
                             variant="ghost"
                             size="icon"
+                            aria-label="Next page"
                             onClick={() => setPage(page + 1)}
                             disabled={page === totalPages}
                         >

--- a/apps/dash/src/status-page/lib/db-queries.ts
+++ b/apps/dash/src/status-page/lib/db-queries.ts
@@ -9,6 +9,10 @@ import {
     timeseries,
 } from "@uptimekit/db";
 import { monitor } from "@uptimekit/db/schema/monitors";
+import {
+    statusPageReport,
+    statusPageReportUpdate,
+} from "@uptimekit/db/schema/status-updates";
 // ... imports
 import {
     and,
@@ -160,68 +164,162 @@ async function getPublishedIncidentRecords(
 
     const incidentIds = (await incidentIdsQuery).map((row) => row.incidentId);
 
-    if (incidentIds.length === 0) {
-        return [];
+    const records =
+        incidentIds.length === 0
+            ? []
+            : await db.query.incidentStatusPage.findMany({
+                  columns: {
+                      incidentId: true,
+                      statusPageId: true,
+                  },
+                  where: and(
+                      eq(incidentStatusPage.statusPageId, statusPageId),
+                      inArray(incidentStatusPage.incidentId, incidentIds),
+                  ),
+                  with: {
+                      incident: {
+                          columns: {
+                              id: true,
+                              title: true,
+                              status: true,
+                              severity: true,
+                              description: true,
+                              startedAt: true,
+                              plannedEndAt: true,
+                              endedAt: true,
+                              createdAt: true,
+                          },
+                          with: {
+                              monitors: {
+                                  columns: {
+                                      incidentId: true,
+                                      monitorId: true,
+                                  },
+                                  with: {
+                                      monitor: {
+                                          columns: {
+                                              id: true,
+                                              name: true,
+                                          },
+                                      },
+                                  },
+                              },
+                              activities: {
+                                  columns: {
+                                      id: true,
+                                      message: true,
+                                      type: true,
+                                      createdAt: true,
+                                  },
+                                  orderBy: [desc(incidentActivity.createdAt)],
+                              },
+                          },
+                      },
+                  },
+              });
+
+    const legacyFilters = [
+        eq(statusPageReport.statusPageId, statusPageId),
+        options?.maintenanceOnly
+            ? eq(statusPageReport.severity, "maintenance")
+            : ne(statusPageReport.severity, "maintenance"),
+    ];
+
+    if (options?.activeOnly) {
+        legacyFilters.push(isNull(statusPageReport.resolvedAt));
     }
 
-    const records = await db.query.incidentStatusPage.findMany({
-        columns: {
-            incidentId: true,
-            statusPageId: true,
-        },
-        where: and(
-            eq(incidentStatusPage.statusPageId, statusPageId),
-            inArray(incidentStatusPage.incidentId, incidentIds),
-        ),
+    if (options?.resolvedOnly) {
+        legacyFilters.push(isNotNull(statusPageReport.resolvedAt));
+    }
+
+    if (options?.cutoff) {
+        const cutoffFilter = or(
+            gte(statusPageReport.createdAt, options.cutoff),
+            isNull(statusPageReport.resolvedAt),
+            gte(statusPageReport.resolvedAt, options.cutoff),
+        );
+        if (cutoffFilter) {
+            legacyFilters.push(cutoffFilter);
+        }
+    }
+
+    const legacyReports = await db.query.statusPageReport.findMany({
+        where: and(...legacyFilters),
+        orderBy: [
+            desc(
+                options?.sortBy === "endedAt"
+                    ? statusPageReport.resolvedAt
+                    : statusPageReport.createdAt,
+            ),
+        ],
         with: {
-            incident: {
-                columns: {
-                    id: true,
-                    title: true,
-                    status: true,
-                    severity: true,
-                    description: true,
-                    startedAt: true,
-                    plannedEndAt: true,
-                    endedAt: true,
-                    createdAt: true,
-                },
+            updates: {
+                orderBy: [desc(statusPageReportUpdate.createdAt)],
+            },
+            affectedMonitors: {
                 with: {
-                    monitors: {
-                        columns: {
-                            incidentId: true,
-                            monitorId: true,
-                        },
-                        with: {
-                            monitor: {
-                                columns: {
-                                    id: true,
-                                    name: true,
-                                },
-                            },
-                        },
-                    },
-                    activities: {
+                    monitor: {
                         columns: {
                             id: true,
-                            message: true,
-                            type: true,
-                            createdAt: true,
+                            name: true,
                         },
-                        orderBy: [desc(incidentActivity.createdAt)],
                     },
                 },
             },
         },
     });
 
+    const legacyRecords = legacyReports.map((report) => ({
+        incidentId: report.id,
+        statusPageId: report.statusPageId,
+        incident: {
+            id: report.id,
+            title: report.title,
+            status: report.status,
+            severity: report.severity,
+            description: null,
+            startedAt: report.createdAt,
+            plannedEndAt: null,
+            endedAt: report.resolvedAt,
+            createdAt: report.createdAt,
+            monitors: report.affectedMonitors.map((item) => ({
+                incidentId: report.id,
+                monitorId: item.monitorId,
+                monitor: item.monitor,
+            })),
+            activities: report.updates.map((update) => ({
+                id: update.id,
+                message: update.message,
+                type: "update",
+                createdAt: update.createdAt,
+            })),
+        },
+    }));
+
+    const allRecords = [...records, ...legacyRecords].sort((a, b) => {
+        const aDate =
+            options?.sortBy === "endedAt"
+                ? a.incident.endedAt
+                : a.incident.startedAt;
+        const bDate =
+            options?.sortBy === "endedAt"
+                ? b.incident.endedAt
+                : b.incident.startedAt;
+        return (bDate?.getTime() ?? 0) - (aDate?.getTime() ?? 0);
+    });
+
+    const limitedRecords = options?.limit
+        ? allRecords.slice(0, options.limit)
+        : allRecords;
+
     const displayNames = await getStatusPageMonitorDisplayNames(statusPageId);
 
     if (displayNames.size === 0) {
-        return records;
+        return limitedRecords;
     }
 
-    return records.map((record) => ({
+    return limitedRecords.map((record) => ({
         ...record,
         incident: {
             ...record.incident,

--- a/apps/dash/src/status-page/lib/db-queries.ts
+++ b/apps/dash/src/status-page/lib/db-queries.ts
@@ -255,7 +255,10 @@ async function getPublishedIncidentRecords(
         ],
         with: {
             updates: {
-                orderBy: [desc(statusPageReportUpdate.createdAt)],
+                orderBy: [
+                    desc(statusPageReportUpdate.createdAt),
+                    desc(statusPageReportUpdate.id),
+                ],
             },
             affectedMonitors: {
                 with: {

--- a/apps/dash/vitest.config.mts
+++ b/apps/dash/vitest.config.mts
@@ -2,6 +2,7 @@ import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+    root: fileURLToPath(new URL(".", import.meta.url)),
     resolve: {
         alias: {
             "@": fileURLToPath(new URL("./src", import.meta.url)),
@@ -14,6 +15,6 @@ export default defineConfig({
     },
     test: {
         environment: "node",
-        include: ["apps/dash/src/**/*.test.{ts,tsx}"],
+        include: ["src/**/*.test.{ts,tsx}"],
     },
 });

--- a/apps/worker/internal/monitor/http.go
+++ b/apps/worker/internal/monitor/http.go
@@ -125,7 +125,7 @@ func (m *HTTPMonitor) Check(cfg Config) Result {
 	defer resp.Body.Close()
 
 	// Read body to complete transfer timing
-	_, _ = io.Copy(io.Discard, resp.Body)
+	_, transferErr := io.Copy(io.Discard, resp.Body)
 	transferDone := time.Now()
 
 	// Calculate timings
@@ -152,6 +152,10 @@ func (m *HTTPMonitor) Check(cfg Config) Result {
 	result.Latency = timings.Total
 	result.Timings = timings
 	result.StatusCode = resp.StatusCode
+	if transferErr != nil {
+		result.Error = "failed to read response: " + transferErr.Error()
+		return result
+	}
 
 	// Check if status code is acceptable
 	isUp := m.isStatusAcceptable(resp.StatusCode, cfg.AcceptedStatusCodes)

--- a/apps/worker/internal/monitor/http_test.go
+++ b/apps/worker/internal/monitor/http_test.go
@@ -1,0 +1,37 @@
+package monitor
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHTTPMonitorResponseTransfer(t *testing.T) {
+	for _, truncated := range []bool{false, true} {
+		name := "complete"
+		if truncated {
+			name = "truncated"
+		}
+		t.Run(name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if truncated {
+					w.Header().Set("Content-Length", "100")
+				}
+				_, _ = w.Write([]byte("ok"))
+			}))
+			defer server.Close()
+			result := NewHTTPMonitor().Check(Config{URL: server.URL, Timeout: 1})
+			if truncated {
+				if result.Status != StatusDown || !strings.Contains(result.Error, "failed to read response") {
+					t.Fatalf("expected failed transfer, got %+v", result)
+				}
+			} else if result.Status != StatusUp {
+				t.Fatalf("expected up, got %+v", result)
+			}
+			if result.StatusCode != 200 || result.Timings == nil {
+				t.Fatalf("expected response diagnostics, got %+v", result)
+			}
+		})
+	}
+}

--- a/packages/api/src/lib/audit-user.test.ts
+++ b/packages/api/src/lib/audit-user.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import type { Context } from "../context";
+import { getAuditUserId } from "./audit-user";
+
+describe("audit user attribution", () => {
+    const session = { user: { id: "user-1" } } as Context["session"];
+
+    it("attributes browser actions to the real user", () => {
+        expect(getAuditUserId({ authType: "session", session })).toBe("user-1");
+    });
+
+    it("does not attribute organization key actions to a browser user or synthetic user", () => {
+        for (const id of ["user-1", "api-key:key-1"]) {
+            expect(
+                getAuditUserId({
+                    authType: "apiKey",
+                    session: { user: { id } } as Context["session"],
+                }),
+            ).toBeNull();
+        }
+    });
+});

--- a/packages/api/src/lib/audit-user.ts
+++ b/packages/api/src/lib/audit-user.ts
@@ -1,0 +1,8 @@
+import type { Context } from "../context";
+
+export function getAuditUserId(context: Pick<Context, "authType" | "session">) {
+    // Organization API keys have no user row, even when sent with a browser cookie.
+    return context.authType === "session"
+        ? (context.session?.user.id ?? null)
+        : null;
+}

--- a/packages/api/src/pkg/integrations/definitions/gchat.ts
+++ b/packages/api/src/pkg/integrations/definitions/gchat.ts
@@ -1,5 +1,5 @@
-import type { z } from "zod";
 import { db } from "@uptimekit/db";
+import type { z } from "zod";
 import { createLogger } from "../../../lib/logger";
 import { fetchIntegrationWebhook } from "../http";
 import type { IntegrationDefinition } from "../registry";
@@ -41,7 +41,9 @@ function decoratedText(
 }
 
 function linkButton(text: string, url: string): GchatWidget {
-    return { buttonList: { buttons: [{ text, onClick: { openLink: { url } } }] } };
+    return {
+        buttonList: { buttons: [{ text, onClick: { openLink: { url } } }] },
+    };
 }
 
 async function sendGchatMessage(webhookUrl: string, message: GchatCardMessage) {
@@ -223,9 +225,8 @@ export const gchatIntegration: IntegrationDefinition<
                 process.env.NEXT_PUBLIC_URL || "http://localhost:3000";
 
             const monitorNames =
-                incidentData?.monitors
-                    .map((m) => m.monitor.name)
-                    .join(", ") || "No monitors";
+                incidentData?.monitors.map((m) => m.monitor.name).join(", ") ||
+                "No monitors";
 
             const incidentUrl = `${baseUrl}/incidents/${payload.incidentId}`;
 

--- a/packages/api/src/routers/incidents.ts
+++ b/packages/api/src/routers/incidents.ts
@@ -11,6 +11,7 @@ import { statusPage } from "@uptimekit/db/schema/status-pages";
 import { and, desc, eq, ilike, inArray, isNull, sql } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure, writeProcedure } from "../index";
+import { getAuditUserId } from "../lib/audit-user";
 import { publishAppEvent } from "../lib/events";
 import { processPendingNotifications } from "../pkg/notifications";
 
@@ -524,7 +525,7 @@ export const incidentsRouter = {
                     message: `Incident created by ${context.session.user.name}`,
                     type: "comment",
                     createdAt: now,
-                    userId: context.session.user.id,
+                    userId: getAuditUserId(context),
                 });
 
                 if (input.statusPageIds.length > 0) {
@@ -534,7 +535,7 @@ export const incidentsRouter = {
                         message: `Published to ${input.statusPageIds.length} status page${input.statusPageIds.length === 1 ? "" : "s"}`,
                         type: "event",
                         createdAt: now,
-                        userId: context.session.user.id,
+                        userId: getAuditUserId(context),
                     });
                 }
 
@@ -733,7 +734,7 @@ export const incidentsRouter = {
                             message,
                             type: "event",
                             createdAt: new Date(),
-                            userId: context.session.user.id,
+                            userId: getAuditUserId(context),
                         })),
                     );
                 }
@@ -795,7 +796,7 @@ export const incidentsRouter = {
                     .set({
                         status: existing.endedAt ? "resolved" : "identified",
                         acknowledgedAt: now,
-                        acknowledgedBy: context.session.user.id,
+                        acknowledgedBy: getAuditUserId(context),
                         updatedAt: now,
                     })
                     .where(eq(incident.id, input.id));
@@ -806,7 +807,7 @@ export const incidentsRouter = {
                     message: `Incident acknowledged by ${context.session.user.name}`,
                     type: "comment",
                     createdAt: now,
-                    userId: context.session.user.id,
+                    userId: getAuditUserId(context),
                 });
 
                 await publishAppEvent(
@@ -877,7 +878,7 @@ export const incidentsRouter = {
                     message: `Incident resolved by ${context.session.user.name}`,
                     type: "comment",
                     createdAt: now,
-                    userId: context.session.user.id,
+                    userId: getAuditUserId(context),
                 });
 
                 await publishAppEvent(
@@ -1040,7 +1041,7 @@ export const incidentsRouter = {
                     message: `Merged ${mergedCount} incident${mergedCount === 1 ? "" : "s"} into this incident: ${sourceTitles.join(", ")}`,
                     type: "event",
                     createdAt: now,
-                    userId: context.session.user.id,
+                    userId: getAuditUserId(context),
                 });
 
                 await tx
@@ -1104,7 +1105,7 @@ export const incidentsRouter = {
                     message: input.message,
                     type: "comment",
                     createdAt: now,
-                    userId: context.session.user.id,
+                    userId: getAuditUserId(context),
                 });
 
                 await publishAppEvent(

--- a/packages/api/src/routers/maintenance.ts
+++ b/packages/api/src/routers/maintenance.ts
@@ -11,6 +11,7 @@ import { statusPage } from "@uptimekit/db/schema/status-pages";
 import { and, desc, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure, writeProcedure } from "../index";
+import { getAuditUserId } from "../lib/audit-user";
 
 const maintenanceStatusSchema = z.enum([
     "scheduled",
@@ -204,7 +205,7 @@ export const maintenanceRouter = {
                         message: input.description,
                         type: "comment",
                         createdAt: now,
-                        userId: context.session.user.id,
+                        userId: getAuditUserId(context),
                     });
                 }
             });
@@ -341,7 +342,7 @@ export const maintenanceRouter = {
                     message: input.message,
                     type: "comment",
                     createdAt: now,
-                    userId: context.session.user.id,
+                    userId: getAuditUserId(context),
                 });
 
                 await tx

--- a/packages/api/src/routers/status-updates.ts
+++ b/packages/api/src/routers/status-updates.ts
@@ -11,6 +11,11 @@ import { z } from "zod";
 import { protectedProcedure, writeProcedure } from "../index";
 import { getAuditUserId } from "../lib/audit-user";
 
+const reportUpdateOrder = [
+    desc(statusPageReportUpdate.createdAt),
+    desc(statusPageReportUpdate.id),
+];
+
 export const statusUpdatesRouter = {
     list: protectedProcedure
         .route({
@@ -54,7 +59,7 @@ export const statusUpdatesRouter = {
                 orderBy: [desc(statusPageReport.createdAt)],
                 with: {
                     updates: {
-                        orderBy: [desc(statusPageReportUpdate.createdAt)],
+                        orderBy: reportUpdateOrder,
                     },
                     affectedMonitors: true,
                 },
@@ -108,7 +113,7 @@ export const statusUpdatesRouter = {
                 ),
                 with: {
                     updates: {
-                        orderBy: [desc(statusPageReportUpdate.createdAt)],
+                        orderBy: reportUpdateOrder,
                     },
                     affectedMonitors: true,
                 },
@@ -292,13 +297,32 @@ export const statusUpdatesRouter = {
                     userId: getAuditUserId(context),
                 });
 
-                // 2. Update the parent report status
+                const [latestUpdate] = await tx
+                    .select({
+                        status: statusPageReportUpdate.status,
+                        createdAt: statusPageReportUpdate.createdAt,
+                    })
+                    .from(statusPageReportUpdate)
+                    .where(eq(statusPageReportUpdate.reportId, input.reportId))
+                    .orderBy(...reportUpdateOrder)
+                    .limit(1);
+
+                if (!latestUpdate) {
+                    throw new ORPCError("INTERNAL_SERVER_ERROR", {
+                        message: "Report has no updates",
+                    });
+                }
+
+                // 2. Keep the parent status derived from the newest update.
                 await tx
                     .update(statusPageReport)
                     .set({
-                        status: input.status,
+                        status: latestUpdate.status,
                         updatedAt: now,
-                        resolvedAt: input.status === "resolved" ? now : null,
+                        resolvedAt:
+                            latestUpdate.status === "resolved"
+                                ? latestUpdate.createdAt
+                                : null,
                     })
                     .where(eq(statusPageReport.id, input.reportId));
 
@@ -424,7 +448,7 @@ export const statusUpdatesRouter = {
                     })
                     .from(statusPageReportUpdate)
                     .where(eq(statusPageReportUpdate.reportId, update.reportId))
-                    .orderBy(desc(statusPageReportUpdate.createdAt))
+                    .orderBy(...reportUpdateOrder)
                     .limit(1);
 
                 if (!latestUpdate) {
@@ -548,7 +572,7 @@ export const statusUpdatesRouter = {
                     })
                     .from(statusPageReportUpdate)
                     .where(eq(statusPageReportUpdate.reportId, update.reportId))
-                    .orderBy(desc(statusPageReportUpdate.createdAt))
+                    .orderBy(...reportUpdateOrder)
                     .limit(1);
 
                 if (!latestUpdate) {

--- a/packages/api/src/routers/status-updates.ts
+++ b/packages/api/src/routers/status-updates.ts
@@ -417,13 +417,32 @@ export const statusUpdatesRouter = {
                     })
                     .where(eq(statusPageReportUpdate.id, input.updateId));
 
-                // 2. Update the parent report status
+                const [latestUpdate] = await tx
+                    .select({
+                        status: statusPageReportUpdate.status,
+                        createdAt: statusPageReportUpdate.createdAt,
+                    })
+                    .from(statusPageReportUpdate)
+                    .where(eq(statusPageReportUpdate.reportId, update.reportId))
+                    .orderBy(desc(statusPageReportUpdate.createdAt))
+                    .limit(1);
+
+                if (!latestUpdate) {
+                    throw new ORPCError("INTERNAL_SERVER_ERROR", {
+                        message: "Report has no updates",
+                    });
+                }
+
+                // 2. Keep the parent status derived from the newest update.
                 await tx
                     .update(statusPageReport)
                     .set({
-                        status: input.status,
+                        status: latestUpdate.status,
                         updatedAt: now,
-                        resolvedAt: input.status === "resolved" ? now : null,
+                        resolvedAt:
+                            latestUpdate.status === "resolved"
+                                ? latestUpdate.createdAt
+                                : null,
                     })
                     .where(eq(statusPageReport.id, update.reportId));
 
@@ -517,9 +536,39 @@ export const statusUpdatesRouter = {
                 });
             }
 
-            await db
-                .delete(statusPageReportUpdate)
-                .where(eq(statusPageReportUpdate.id, input.updateId));
+            await db.transaction(async (tx) => {
+                await tx
+                    .delete(statusPageReportUpdate)
+                    .where(eq(statusPageReportUpdate.id, input.updateId));
+
+                const [latestUpdate] = await tx
+                    .select({
+                        status: statusPageReportUpdate.status,
+                        createdAt: statusPageReportUpdate.createdAt,
+                    })
+                    .from(statusPageReportUpdate)
+                    .where(eq(statusPageReportUpdate.reportId, update.reportId))
+                    .orderBy(desc(statusPageReportUpdate.createdAt))
+                    .limit(1);
+
+                if (!latestUpdate) {
+                    throw new ORPCError("INTERNAL_SERVER_ERROR", {
+                        message: "Report has no updates",
+                    });
+                }
+
+                await tx
+                    .update(statusPageReport)
+                    .set({
+                        status: latestUpdate.status,
+                        updatedAt: new Date(),
+                        resolvedAt:
+                            latestUpdate.status === "resolved"
+                                ? latestUpdate.createdAt
+                                : null,
+                    })
+                    .where(eq(statusPageReport.id, update.reportId));
+            });
 
             return { success: true };
         }),

--- a/packages/api/src/routers/status-updates.ts
+++ b/packages/api/src/routers/status-updates.ts
@@ -9,6 +9,7 @@ import {
 import { and, desc, eq } from "drizzle-orm";
 import { z } from "zod";
 import { protectedProcedure, writeProcedure } from "../index";
+import { getAuditUserId } from "../lib/audit-user";
 
 export const statusUpdatesRouter = {
     list: protectedProcedure
@@ -196,7 +197,7 @@ export const statusUpdatesRouter = {
                     message: input.message,
                     status: input.status,
                     createdAt: now,
-                    userId: context.session.user.id,
+                    userId: getAuditUserId(context),
                 });
 
                 if (input.monitors.length > 0) {
@@ -288,7 +289,7 @@ export const statusUpdatesRouter = {
                     message: input.message,
                     status: input.status,
                     createdAt: now,
-                    userId: context.session.user.id,
+                    userId: getAuditUserId(context),
                 });
 
                 // 2. Update the parent report status


### PR DESCRIPTION
## Summary

- Preserve legacy status-page reports and latest report status when editing or deleting updates.
- Detect HTTP response transfer failures and mark checks down.
- Avoid attributing API key actions to browser users in audit records.
- Add pagination button labels and include dashboard tests in workspace runs.
- Apply Google Chat integration formatting fixes.

## Testing

- Added worker coverage for complete and truncated HTTP responses.
- Added audit-user attribution tests.
- Not run: full test suite.